### PR TITLE
Add a test for chan to testing return a rpc error

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -62,6 +62,10 @@ func (h *SimpleServerHandler) StringMatch(t TestType, i2 int64) (out TestOut, er
 	return
 }
 
+func (h *SimpleServerHandler) ErrChanSub(ctx context.Context) (<-chan int, error) {
+	return nil, errors.New("expect to return an error")
+}
+
 func TestRPC(t *testing.T) {
 	// setup server
 
@@ -79,6 +83,7 @@ func TestRPC(t *testing.T) {
 		Add         func(int) error
 		AddGet      func(int) int
 		StringMatch func(t TestType, i2 int64) (out TestOut, err error)
+		ErrChanSub  func(context.Context) (<-chan int, error)
 	}
 	closer, err := NewClient("ws://"+testServ.Listener.Addr().String(), "SimpleServerHandler", &client, nil)
 	require.NoError(t, err)
@@ -112,6 +117,16 @@ func TestRPC(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "8", o.S)
 	require.Equal(t, 8, o.I)
+
+	// ErrChanSub
+	ctx := context.TODO()
+	// SPEC:
+	// need define a ctx for chan return, or it should panic for client.go:174#reflect.ValueOf(ctx.Done())
+	_, err = client.ErrChanSub(ctx)
+	if err == nil {
+		t.Fatal("expect an err return, but got nil")
+	}
+	//require.Error(t, ErrChanTest, err)
 
 	// Invalid client handlers
 


### PR DESCRIPTION
This testing PR needs the issue https://github.com/filecoin-project/go-jsonrpc/issues/14 be fixed before merging, or it should have a fail test.

test command:
```
go test -test.run=TestRPC
```

current output log:
```
2020-07-18T14:26:15.215Z	WARN	rpc	go-jsonrpc/handler.go:226	error in RPC call to 'SimpleServerHandler.Add': test
2020-07-18T14:26:15.216Z	DEBUG	rpc	go-jsonrpc/client.go:404	rpc result	{"type": "int"}
2020-07-18T14:26:15.217Z	DEBUG	rpc	go-jsonrpc/client.go:404	rpc result	{"type": "jsonrpc.TestOut"}
2020-07-18T14:26:15.217Z	WARN	rpc	go-jsonrpc/handler.go:226	error in RPC call to 'SimpleServerHandler.StringMatch': :(
2020-07-18T14:26:15.218Z	DEBUG	rpc	go-jsonrpc/client.go:404	rpc result	{"type": "jsonrpc.TestOut"}
2020-07-18T14:26:15.218Z	WARN	rpc	go-jsonrpc/handler.go:226	error in RPC call to 'SimpleServerHandler.ErrChanSub': expect to return an error
--- FAIL: TestRPC (0.01s)
    rpc_test.go:127: expect an err return, but got nil
FAIL
exit status 1
FAIL	github.com/filecoin-project/go-jsonrpc	0.017s

shell returned 1
```

expect:
testing pass
