### PR TITLE
Support error codes / typed errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,37 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+type Errors struct {
+	byType map[reflect.Type]ErrorCode
+	byCode map[ErrorCode]reflect.Type
+}
+
+type ErrorCode int
+
+const FirstUserCode = 2
+
+func NewErrors() Errors {
+	return Errors{
+		byType: map[reflect.Type]ErrorCode{},
+		byCode: map[ErrorCode]reflect.Type{},
+	}
+}
+
+func (e *Errors) Register(c ErrorCode, typ interface{}) {
+	rt := reflect.TypeOf(typ).Elem()
+	if !rt.Implements(errorType) {
+		panic("can't register non-error types")
+	}
+
+	e.byType[rt] = c
+	e.byCode[c] = rt
+}
+
+type marshalable interface {
+	json.Marshaler
+	json.Unmarshaler
+}

--- a/handler.go
+++ b/handler.go
@@ -62,7 +62,7 @@ func (e *respError) Error() string {
 	return e.Message
 }
 
-var marsharableRT = reflect.TypeOf(new(marshalable)).Elem()
+var marshalableRT = reflect.TypeOf(new(marshalable)).Elem()
 
 func (e *respError) val(errors *Errors) reflect.Value {
 	if errors != nil {
@@ -74,7 +74,7 @@ func (e *respError) val(errors *Errors) reflect.Value {
 			} else {
 				v = reflect.New(t)
 			}
-			if len(e.Meta) > 0 && v.Type().Implements(marsharableRT) {
+			if len(e.Meta) > 0 && v.Type().Implements(marshalableRT) {
 				_ = v.Interface().(marshalable).UnmarshalJSON(e.Meta)
 			}
 			if t.Kind() != reflect.Ptr {

--- a/handler.go
+++ b/handler.go
@@ -50,8 +50,9 @@ type request struct {
 const DEFAULT_MAX_REQUEST_SIZE = 100 << 20 // 100 MiB
 
 type respError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Code    ErrorCode       `json:"code"`
+	Message string          `json:"message"`
+	Meta    json.RawMessage `json:"meta,omitempty"`
 }
 
 func (e *respError) Error() string {
@@ -59,6 +60,31 @@ func (e *respError) Error() string {
 		return fmt.Sprintf("RPC error (%d): %s", e.Code, e.Message)
 	}
 	return e.Message
+}
+
+var marsharableRT = reflect.TypeOf(new(marshalable)).Elem()
+
+func (e *respError) val(errors *Errors) reflect.Value {
+	if errors != nil {
+		t, ok := errors.byCode[e.Code]
+		if ok {
+			var v reflect.Value
+			if t.Kind() == reflect.Ptr {
+				v = reflect.New(t.Elem())
+			} else {
+				v = reflect.New(t)
+			}
+			if len(e.Meta) > 0 && v.Type().Implements(marsharableRT) {
+				_ = v.Interface().(marshalable).UnmarshalJSON(e.Meta)
+			}
+			if t.Kind() != reflect.Ptr {
+				v = v.Elem()
+			}
+			return v
+		}
+	}
+
+	return reflect.ValueOf(e)
 }
 
 type response struct {
@@ -108,7 +134,7 @@ func (s *RPCServer) register(namespace string, r interface{}) {
 
 // Handle
 
-type rpcErrFunc func(w func(func(io.Writer)), req *request, code int, err error)
+type rpcErrFunc func(w func(func(io.Writer)), req *request, code ErrorCode, err error)
 type chanOut func(reflect.Value, int64) error
 
 func (s *RPCServer) handleReader(ctx context.Context, r io.Reader, w io.Writer, rpcError rpcErrFunc) {
@@ -184,6 +210,30 @@ func (s *RPCServer) getSpan(ctx context.Context, req request) (context.Context, 
 		return ctx, span
 	}
 	return ctx, nil
+}
+
+func (s *RPCServer) createError(err error) *respError {
+	var code ErrorCode = 1
+	if s.errors != nil {
+		c, ok := s.errors.byType[reflect.TypeOf(err)]
+		if ok {
+			code = c
+		}
+	}
+
+	out := &respError{
+		Code:    code,
+		Message: err.(error).Error(),
+	}
+
+	if m, ok := err.(marshalable); ok {
+		meta, err := m.MarshalJSON()
+		if err == nil {
+			out.Meta = meta
+		}
+	}
+
+	return out
 }
 
 func (s *RPCServer) handle(ctx context.Context, req request, w func(func(io.Writer)), rpcError rpcErrFunc, done func(keepCtx bool), chOut chanOut) {
@@ -278,10 +328,8 @@ func (s *RPCServer) handle(ctx context.Context, req request, w func(func(io.Writ
 		if err != nil {
 			log.Warnf("error in RPC call to '%s': %+v", req.Method, err)
 			stats.Record(ctx, metrics.RPCResponseError.M(1))
-			resp.Error = &respError{
-				Code:    1,
-				Message: err.(error).Error(),
-			}
+
+			resp.Error = s.createError(err.(error))
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -15,6 +15,7 @@ type Config struct {
 	timeout          time.Duration
 
 	paramEncoders map[reflect.Type]ParamEncoder
+	errors        *Errors
 
 	noReconnect      bool
 	proxyConnFactory func(func() (*websocket.Conn, error)) func() (*websocket.Conn, error) // for testing
@@ -66,5 +67,11 @@ func WithNoReconnect() func(c *Config) {
 func WithParamEncoder(t interface{}, encoder ParamEncoder) func(c *Config) {
 	return func(c *Config) {
 		c.paramEncoders[reflect.TypeOf(t).Elem()] = encoder
+	}
+}
+
+func WithErrors(es Errors) func(c *Config) {
+	return func(c *Config) {
+		c.errors = &es
 	}
 }

--- a/options_server.go
+++ b/options_server.go
@@ -10,6 +10,7 @@ type ParamDecoder func(ctx context.Context, json []byte) (reflect.Value, error)
 type ServerConfig struct {
 	paramDecoders  map[reflect.Type]ParamDecoder
 	maxRequestSize int64
+	errors         *Errors
 }
 
 type ServerOption func(c *ServerConfig)
@@ -30,5 +31,11 @@ func WithParamDecoder(t interface{}, decoder ParamDecoder) ServerOption {
 func WithMaxRequestSize(max int64) ServerOption {
 	return func(c *ServerConfig) {
 		c.maxRequestSize = max
+	}
+}
+
+func WithServerErrors(es Errors) ServerOption {
+	return func(c *ServerConfig) {
+		c.errors = &es
 	}
 }

--- a/server.go
+++ b/server.go
@@ -20,6 +20,7 @@ const (
 // RPCServer provides a jsonrpc 2.0 http server handler
 type RPCServer struct {
 	methods map[string]rpcHandler
+	errors  *Errors
 
 	// aliasedMethods contains a map of alias:original method names.
 	// These are used as fallbacks if a method is not found by the given method name.
@@ -42,6 +43,7 @@ func NewServer(opts ...ServerOption) *RPCServer {
 		aliasedMethods: map[string]string{},
 		paramDecoders:  config.paramDecoders,
 		maxRequestSize: config.maxRequestSize,
+		errors:         config.errors,
 	}
 }
 
@@ -91,7 +93,7 @@ func (s *RPCServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.handleReader(ctx, r.Body, w, rpcError)
 }
 
-func rpcError(wf func(func(io.Writer)), req *request, code int, err error) {
+func rpcError(wf func(func(io.Writer)), req *request, code ErrorCode, err error) {
 	log.Errorf("RPC Error: %s", err)
 	wf(func(w io.Writer) {
 		if hw, ok := w.(http.ResponseWriter); ok {

--- a/websocket.go
+++ b/websocket.go
@@ -19,6 +19,8 @@ const wsCancel = "xrpc.cancel"
 const chValue = "xrpc.ch.val"
 const chClose = "xrpc.ch.close"
 
+const eTempWSError = -1111111
+
 type frame struct {
 	// common
 	Jsonrpc string            `json:"jsonrpc"`
@@ -451,7 +453,7 @@ func (c *wsConn) closeInFlight() {
 			ID:      id,
 			Error: &respError{
 				Message: "handler: websocket connection closed",
-				Code:    2,
+				Code:    eTempWSError,
 			},
 		}
 	}
@@ -635,7 +637,7 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 						ID:      *req.req.ID,
 						Error: &respError{
 							Message: "handler: websocket connection closed",
-							Code:    2,
+							Code:    eTempWSError,
 						},
 					}
 					c.writeLk.Unlock()


### PR DESCRIPTION
This will allow returning more actionable errors from RPC calls - e.g. 'balance too low' when pushing messages