### PR TITLE
jsonrpc: add RPCServer.AliasMethod method

### DIFF
--- a/server.go
+++ b/server.go
@@ -19,7 +19,11 @@ const (
 
 // RPCServer provides a jsonrpc 2.0 http server handler
 type RPCServer struct {
-	methods map[string]rpcHandler
+	methods        map[string]rpcHandler
+
+	// aliasedMethods contains a map of alias:original method names.
+	// These are used as fallbacks if a method is not found by the given method name.
+	aliasedMethods map[string]string
 
 	paramDecoders map[reflect.Type]ParamDecoder
 
@@ -35,6 +39,7 @@ func NewServer(opts ...ServerOption) *RPCServer {
 
 	return &RPCServer{
 		methods:        map[string]rpcHandler{},
+		aliasedMethods: map[string]string{},
 		paramDecoders:  config.paramDecoders,
 		maxRequestSize: config.maxRequestSize,
 	}
@@ -121,6 +126,10 @@ func rpcError(wf func(func(io.Writer)), req *request, code int, err error) {
 // Handler is any value with methods defined
 func (s *RPCServer) Register(namespace string, handler interface{}) {
 	s.register(namespace, handler)
+}
+
+func (s *RPCServer) AliasMethod(alias, original string) {
+	s.aliasedMethods[alias] = original
 }
 
 var _ error = &respError{}


### PR DESCRIPTION
Adds this method and supporting struct field aliasedMethods
to provide feature support for method aliasing.

Methods are only queried by their alias when
the provided method name is not found in the
original registry, making the aliases essentially
fallback values.

If no alias is found for a given method,
the error 'method not found' is returned
in the same way as it was before this feature
was added.

Note that this method was added as a solution
to handling the implementation of rpc.discover
method at filecoin-project/lotus.

The RPC specification defines rpc.-prefixed
methods as 'system extensions', and handles
them as their own class of methods apart from
other API methods. As such, further development
may be interested in changing or extending
method aliasing to specification-congruent
handling of system extension methods.

Date: 2020-11-21 09:11:35-06:00
Signed-off-by: meows <b5c6@protonmail.com>