### PR TITLE
fix excessive amount of connections ending up in TIME_WAIT

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -30,6 +31,23 @@ var (
 	contextType = reflect.TypeOf(new(context.Context)).Elem()
 
 	log = logging.Logger("rpc")
+
+	 _defaultHTTPClient = &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			MaxIdleConnsPerHost:   100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
 )
 
 // ErrClient is an error which occurred on the client side the library
@@ -140,7 +158,7 @@ func httpClient(ctx context.Context, addr string, namespace string, outs []inter
 
 		hreq.Header.Set("Content-Type", "application/json")
 
-		httpResp, err := http.DefaultClient.Do(hreq)
+		httpResp, err := _defaultHTTPClient.Do(hreq)
 		if err != nil {
 			return clientResponse{}, err
 		}


### PR DESCRIPTION
@Stebalien @magik6k 

The current implementation using http.DefaultClient has the default MaxIdleConnsPerHost to 2. When there are multiple concurrent RPC requests, only first 2 will remain in the pool. It could accumulate thousands or tens of thousands of connections in the TIME_WAIT state. TIME_WAIT will stay for 2 x Maximum Segment Lifetime (~ 4 minutes). Eventually you will run out of ephemeral ports and not be able to open new client connections.

Below is the worker and netstat info in our miner which incurs many errors of connection refused

P1 Worker Info
`
   lotus-miner sealing workers | grep 10.0.8.114:7991       
`
`
Worker 9ec484f2-57e1-428b-a2d5-c0c6ad386aa2, hostname AA
`
Connections in TIME_WAIT
`
   netstat -na | grep TIME_WAIT | grep 10.0.8.114:7991 | wc -l
`
`
3481
`
Error Log

worker.log
`
2020-11-25T15:28:08.682+0800    ^[[33mWARN^[[0m auth    auth/handler.go:39      JWT Verification failed (originating from 10.0.8.101:54864): RPC client error: sendRequest failed: Post "http://10.0.8.101:XXXXX/rpc/v0": dial tcp 10.0.8.101:XXXXX: connect: connection refused
`
worker
`
   nc -vz 10.0.8.101 XXXXX
`
`
Connection to 10.0.8.101 XXXXX port [tcp/*] succeeded!
`

Changing MaxIdleConnsPerHost from 2 to 100 should resolve this issue [4981](https://github.com/filecoin-project/lotus/issues/4981).