### PR TITLE
Message ID can be int, string, or null as per OpenRPC spec

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -68,11 +68,7 @@ func (r *requestID) UnmarshalJSON(data []byte) error {
 
 func (r requestID) MarshalJSON() ([]byte, error) {
 	switch r.actual.(type) {
-	case nil:
-		return []byte("null"), nil
-	case int64:
-		return json.Marshal(r.actual)
-	case string:
+	case nil, int64, string:
 		return json.Marshal(r.actual)
 	default:
 		return nil, fmt.Errorf("unexpected ID type: %T", r.actual)

--- a/handler.go
+++ b/handler.go
@@ -67,7 +67,16 @@ func (r *requestID) UnmarshalJSON(data []byte) error {
 }
 
 func (r requestID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(r.actual)
+	switch r.actual.(type) {
+	case nil:
+		return []byte("null"), nil
+	case int64:
+		return json.Marshal(r.actual)
+	case string:
+		return json.Marshal(r.actual)
+	default:
+		return nil, fmt.Errorf("unexpected ID type: %T", r.actual)
+	}
 }
 
 // Limit request size. Ideally this limit should be specific for each field

--- a/server.go
+++ b/server.go
@@ -100,13 +100,13 @@ func rpcError(wf func(func(io.Writer)), req *request, code int, err error) {
 
 		log.Warnf("rpc error: %s", err)
 
-		if req.ID == nil { // notification
+		if req.ID.actual == nil { // notification
 			return
 		}
 
 		resp := response{
 			Jsonrpc: "2.0",
-			ID:      *req.ID,
+			ID:      req.ID,
 			Error: &respError{
 				Code:    code,
 				Message: err.Error(),

--- a/websocket.go
+++ b/websocket.go
@@ -187,7 +187,7 @@ func (c *wsConn) handleOutChans() {
 			c.nextWriter(func(w io.Writer) {
 				resp := &response{
 					Jsonrpc: "2.0",
-					ID:      requestID{registration.reqID},
+					ID:      registration.reqID,
 					Result:  registration.chID,
 				}
 


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/go-jsonrpc/issues/28