### PR TITLE
When the context timeout, no longer wait for the call result

### DIFF
--- a/server.go
+++ b/server.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	rpcParseError     = -32700
-	rpcMethodNotFound = -32601
-	rpcInvalidParams  = -32602
+	rpcParseError       = -32700
+	rpcMethodNotFound   = -32601
+	rpcInvalidParams    = -32602
+	rpcApplicationError = -32500
 )
 
 // RPCServer provides a jsonrpc 2.0 http server handler


### PR DESCRIPTION
I use the websocket client to request remote services and add a timeout to the context, but the timeout does not seem to work. I expect to return immediately after the timeout, instead of waiting for the result of the call.