### PR TITLE
Adding HTTP Transport parameters can be modified

### DIFF
--- a/client.go
+++ b/client.go
@@ -158,6 +158,9 @@ func httpClient(ctx context.Context, addr string, namespace string, outs []inter
 
 		hreq.Header.Set("Content-Type", "application/json")
 
+		if config.transport != nil {
+			_defaultHTTPClient.Transport = config.transport
+		}
 		httpResp, err := _defaultHTTPClient.Do(hreq)
 		if err != nil {
 			return clientResponse{}, err

--- a/options.go
+++ b/options.go
@@ -1,11 +1,28 @@
 package jsonrpc
 
 import (
+	"net"
+	"net/http"
 	"reflect"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
+
+var _defaultTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}).DialContext,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	MaxIdleConnsPerHost:   100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}
 
 type ParamEncoder func(reflect.Value) (reflect.Value, error)
 
@@ -18,6 +35,8 @@ type Config struct {
 
 	noReconnect      bool
 	proxyConnFactory func(func() (*websocket.Conn, error)) func() (*websocket.Conn, error) // for testing
+
+	transport *http.Transport
 }
 
 func defaultConfig() Config {
@@ -30,6 +49,8 @@ func defaultConfig() Config {
 		timeout:      30 * time.Second,
 
 		paramEncoders: map[reflect.Type]ParamEncoder{},
+
+		transport: _defaultTransport,
 	}
 }
 
@@ -66,5 +87,39 @@ func WithNoReconnect() func(c *Config) {
 func WithParamEncoder(t interface{}, encoder ParamEncoder) func(c *Config) {
 	return func(c *Config) {
 		c.paramEncoders[reflect.TypeOf(t).Elem()] = encoder
+	}
+}
+
+func WithTransportMaxIdleConns(value int) func(c *Config) {
+	return func(c *Config) {
+		c.transport.MaxIdleConns = value
+	}
+}
+
+func WithTransportMaxIdleConnsPerHost(value int) func(c *Config) {
+	return func(c *Config) {
+		c.transport.MaxIdleConnsPerHost = value
+	}
+}
+
+func WithTransportIdleConnTimeout(valueSecond time.Duration) func(c *Config) {
+	return func(c *Config) {
+		c.transport.IdleConnTimeout = valueSecond * time.Second
+	}
+}
+
+func WithTransportTLSHandshakeTimeout(valueSecond time.Duration) func(c *Config) {
+	return func(c *Config) {
+		c.transport.TLSHandshakeTimeout = valueSecond * time.Second
+	}
+}
+
+func WithTransportDialContext(timeoutSecond, keepAliveSecond time.Duration) func(c *Config) {
+	return func(c *Config) {
+		c.transport.DialContext = (&net.Dialer{
+			Timeout:   timeoutSecond * time.Second,
+			KeepAlive: keepAliveSecond * time.Second,
+			DualStack: true,
+		}).DialContext
 	}
 }


### PR DESCRIPTION
Using the parameters of NewMergeClient, HTTP Transport  can be set .