### PR TITLE
make retry backoff configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -266,7 +266,7 @@ func websocketClient(ctx context.Context, addr string, namespace string, outs []
 	go (&wsConn{
 		conn:             conn,
 		connFactory:      connFactory,
-		reconnectBackoff: config.retryBackoff,
+		reconnectBackoff: config.reconnectBackoff,
 		pingInterval:     config.pingInterval,
 		timeout:          config.timeout,
 		handler:          nil,

--- a/options.go
+++ b/options.go
@@ -16,6 +16,7 @@ type ParamEncoder func(reflect.Value) (reflect.Value, error)
 
 type Config struct {
 	retryBackoff backoff
+	reconnectBackoff backoff
 	pingInterval     time.Duration
 	timeout          time.Duration
 
@@ -28,6 +29,10 @@ type Config struct {
 
 func defaultConfig() Config {
 	return Config{
+		reconnectBackoff: backoff{
+			minDelay: 100 * time.Millisecond,
+			maxDelay: 5 * time.Second,
+		},
 		retryBackoff: backoff{
 			minDelay: methodMinRetryDelay,
 			maxDelay: methodMaxRetryDelay,
@@ -43,12 +48,22 @@ type Option func(c *Config)
 
 func WithReconnectBackoff(minDelay, maxDelay time.Duration) func(c *Config) {
 	return func(c *Config) {
+		c.reconnectBackoff = backoff{
+			minDelay: minDelay,
+			maxDelay: maxDelay,
+		}
+	}
+}
+
+func WithRetryBackoff(minDelay, maxDelay time.Duration) func(c *Config) {
+	return func(c *Config) {
 		c.retryBackoff = backoff{
 			minDelay: minDelay,
 			maxDelay: maxDelay,
 		}
 	}
 }
+
 
 // Must be < Timeout/2
 func WithPingInterval(d time.Duration) func(c *Config) {

--- a/options.go
+++ b/options.go
@@ -7,10 +7,15 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+const (
+	methodMinRetryDelay = 100 * time.Millisecond
+	methodMaxRetryDelay = 10 * time.Minute
+)
+
 type ParamEncoder func(reflect.Value) (reflect.Value, error)
 
 type Config struct {
-	reconnectBackoff backoff
+	retryBackoff backoff
 	pingInterval     time.Duration
 	timeout          time.Duration
 
@@ -23,9 +28,9 @@ type Config struct {
 
 func defaultConfig() Config {
 	return Config{
-		reconnectBackoff: backoff{
-			minDelay: 100 * time.Millisecond,
-			maxDelay: 5 * time.Second,
+		retryBackoff: backoff{
+			minDelay: methodMinRetryDelay,
+			maxDelay: methodMaxRetryDelay,
 		},
 		pingInterval: 5 * time.Second,
 		timeout:      30 * time.Second,
@@ -38,7 +43,7 @@ type Option func(c *Config)
 
 func WithReconnectBackoff(minDelay, maxDelay time.Duration) func(c *Config) {
 	return func(c *Config) {
-		c.reconnectBackoff = backoff{
+		c.retryBackoff = backoff{
 			minDelay: minDelay,
 			maxDelay: maxDelay,
 		}

--- a/util.go
+++ b/util.go
@@ -73,7 +73,7 @@ func (b *backoff) next(attempt int) time.Duration {
 
 	delay := time.Duration(durf)
 
-	if delay > b.maxDelay {
+	if delay > b.maxDelay || delay < 0 { //overflow
 		return b.maxDelay
 	}
 


### PR DESCRIPTION
10 minutes is too long to retry, allow the user to configure a shorter time