### PR TITLE
fix: check http status if request may fail

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,6 +164,12 @@ func httpClient(ctx context.Context, addr string, namespace string, outs []inter
 		if err != nil {
 			return clientResponse{}, &RPCConnectionError{err}
 		}
+
+		// may be fail
+		if httpResp.StatusCode >= http.StatusBadRequest {
+			return clientResponse{}, xerrors.Errorf("request failed, http status %s", httpResp.Status)
+		}
+
 		defer httpResp.Body.Close()
 
 		var resp clientResponse


### PR DESCRIPTION
I don’t think we only check the `json.NewDecoder` error. When the http status is 504, `json decode` will not report an error, and the `clientResponse` structure will return as expected. However, the clientResponse.ID=0 of the structure will eventually result in an error: request and response id didn’t 't match.