### PR TITLE
check for nil err

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package jsonrpc
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 )
 
@@ -12,11 +13,17 @@ type RPCConnectionError struct {
 }
 
 func (e *RPCConnectionError) Error() string {
-	return e.err.Error()
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return "RPCConnectionError"
 }
 
 func (e *RPCConnectionError) Unwrap() error {
-	return e.err
+	if e.err != nil {
+		return e.err
+	}
+	return errors.New("RPCConnectionError")
 }
 
 type Errors struct {


### PR DESCRIPTION
We are getting panics in Boost, because a lower level Lotus API is somehow returning `RPCConnectionError` with `nil` wrapped error. See: https://github.com/filecoin-project/boost/issues/965

Probably a good idea to not crash the process, when we can't enforce the creation of these errors with nil underlying errors.