### PR TITLE
feat: add support for batch requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,7 +144,7 @@ func httpClient(ctx context.Context, addr string, namespace string, outs []inter
 	c.doRequest = func(ctx context.Context, cr clientRequest) (clientResponse, error) {
 		b, err := json.Marshal(&cr.req)
 		if err != nil {
-			return clientResponse{}, xerrors.Errorf("mershaling requset: %w", err)
+			return clientResponse{}, xerrors.Errorf("marshaling requset: %w", err)
 		}
 
 		hreq, err := http.NewRequest("POST", addr, bytes.NewReader(b))

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1139,3 +1139,36 @@ func TestIDHandling(t *testing.T) {
 		})
 	}
 }
+
+func TestIDArrayHandling(t *testing.T) {
+	cases := []struct {
+		str       string
+		expect    interface{}
+		expectErr bool
+	}{
+		{`[{"id":1234,"jsonrpc":"2.0","method":"eth_blockNumber","params":[]}]`, float64(1234), false},
+		{`[{"id":4567,"jsonrpc":"2.0","method":"eth_blockNumber","params":[]}]`, float64(4567), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v", tc.expect), func(t *testing.T) {
+
+			// if tc.str is array
+			if tc.str[0] == '[' {
+				dec := json.NewDecoder(strings.NewReader(tc.str))
+				var arr []request
+				require.NoError(t, dec.Decode(&arr))
+				for _, req := range arr {
+					if id, err := normalizeID(req.ID); !tc.expectErr {
+						require.NoError(t, err)
+						require.Equal(t, tc.expect, id)
+					} else {
+						require.Error(t, err)
+					}
+				}
+			}
+		})
+	}
+}
+
+//


### PR DESCRIPTION
# Context

[Batched requests](https://www.jsonrpc.org/specification#batch) are an optional feature in the JSON-RPC 2.0 specification. However, Ethereum clients offer this feature and downstream users like block explorers (e.g. Blockscout) depend on it.

# Change
This adds support for batch request as per specs here [Batched requests](https://www.jsonrpc.org/specification#batch)

# Related Issue
https://github.com/filecoin-project/ref-fvm/issues/1047