### PR TITLE
Features for reverse calls, notifs, custom-params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.13
+      - image: cimg/go:1.18.8
     resource_class: medium
 jobs:
   test:
@@ -31,7 +31,7 @@ jobs:
       - go/mod-download
       - go/install-golangci-lint:
           gobin: $HOME/.local/bin
-          version: 1.23.8
+          version: 1.50.1
       - run:
           command: $HOME/.local/bin/golangci-lint run -v --concurrency 2
 workflows:

--- a/client.go
+++ b/client.go
@@ -226,13 +226,22 @@ func websocketClient(ctx context.Context, addr string, namespace string, outs []
 	exiting := make(chan struct{})
 	c.exiting = exiting
 
+	var hnd reqestHandler
+	if len(config.reverseHandlers) > 0 {
+		h := makeHandler(defaultServerConfig())
+		for _, reverseHandler := range config.reverseHandlers {
+			h.register(reverseHandler.ns, reverseHandler.hnd)
+		}
+		hnd = h
+	}
+
 	go (&wsConn{
 		conn:             conn,
 		connFactory:      connFactory,
 		reconnectBackoff: config.reconnectBackoff,
 		pingInterval:     config.pingInterval,
 		timeout:          config.timeout,
-		handler:          nil,
+		handler:          hnd,
 		requests:         requests,
 		stop:             stop,
 		exiting:          exiting,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/filecoin-project/go-jsonrpc
 
-go 1.14
+go 1.18
 
 require (
 	github.com/google/uuid v1.1.1
@@ -11,4 +11,13 @@ require (
 	go.opencensus.io v0.22.3
 	go.uber.org/zap v1.14.1
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/handler.go
+++ b/handler.go
@@ -281,7 +281,7 @@ func (s *handler) createError(err error) *respError {
 
 	out := &respError{
 		Code:    code,
-		Message: err.(error).Error(),
+		Message: err.Error(),
 	}
 
 	if m, ok := err.(marshalable); ok {
@@ -434,7 +434,7 @@ func (s *handler) handle(ctx context.Context, req request, w func(func(io.Writer
 			stats.Record(ctx, metrics.RPCResponseError.M(1))
 			resp.Error = &respError{
 				Code:    1,
-				Message: err.(error).Error(),
+				Message: err.Error(),
 			}
 		} else {
 			resp.Result = res

--- a/options.go
+++ b/options.go
@@ -23,7 +23,8 @@ type Config struct {
 	paramEncoders map[reflect.Type]ParamEncoder
 	errors        *Errors
 
-	reverseHandlers []clientHandler
+	reverseHandlers       []clientHandler
+	aliasedHandlerMethods map[string]string
 
 	httpClient *http.Client
 
@@ -39,6 +40,8 @@ func defaultConfig() Config {
 		},
 		pingInterval: 5 * time.Second,
 		timeout:      30 * time.Second,
+
+		aliasedHandlerMethods: map[string]string{},
 
 		paramEncoders: map[reflect.Type]ParamEncoder{},
 
@@ -91,6 +94,14 @@ func WithErrors(es Errors) func(c *Config) {
 func WithClientHandler(ns string, hnd interface{}) func(c *Config) {
 	return func(c *Config) {
 		c.reverseHandlers = append(c.reverseHandlers, clientHandler{ns, hnd})
+	}
+}
+
+// WithClientHandlerAlias creates an alias for a client HANDLER method - for handlers created
+// with WithClientHandler
+func WithClientHandlerAlias(alias, original string) func(c *Config) {
+	return func(c *Config) {
+		c.aliasedHandlerMethods[alias] = original
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -10,6 +10,11 @@ import (
 
 type ParamEncoder func(reflect.Value) (reflect.Value, error)
 
+type clientHandler struct {
+	ns  string
+	hnd interface{}
+}
+
 type Config struct {
 	reconnectBackoff backoff
 	pingInterval     time.Duration
@@ -17,6 +22,8 @@ type Config struct {
 
 	paramEncoders map[reflect.Type]ParamEncoder
 	errors        *Errors
+
+	reverseHandlers []clientHandler
 
 	httpClient *http.Client
 
@@ -78,6 +85,12 @@ func WithParamEncoder(t interface{}, encoder ParamEncoder) func(c *Config) {
 func WithErrors(es Errors) func(c *Config) {
 	return func(c *Config) {
 		c.errors = &es
+	}
+}
+
+func WithClientHandler(ns string, hnd interface{}) func(c *Config) {
+	return func(c *Config) {
+		c.reverseHandlers = append(c.reverseHandlers, clientHandler{ns, hnd})
 	}
 }
 

--- a/options_server.go
+++ b/options_server.go
@@ -72,7 +72,7 @@ func WithReverseClient[RP any](namespace string) ServerOption {
 			stop := make(chan struct{}) // todo better stop?
 			cl.exiting = stop
 
-			requests := cl.setup()
+			requests := cl.setupRequestChan()
 			conn.requests = requests
 
 			calls := new(RP)

--- a/options_server.go
+++ b/options_server.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// note: we embed reflect.Type because proxy-structs are not comparable
 type jsonrpcReverseClient struct{ reflect.Type }
 
 type ParamDecoder func(ctx context.Context, json []byte) (reflect.Value, error)
@@ -57,6 +58,8 @@ func WithServerPingInterval(d time.Duration) ServerOption {
 	}
 }
 
+// WithReverseClient will allow extracting reverse client on **WEBSOCKET** calls.
+// RP is a proxy-struct type, much like the one passed to NewClient.
 func WithReverseClient[RP any](namespace string) ServerOption {
 	return func(c *ServerConfig) {
 		c.reverseClientBuilder = func(ctx context.Context, conn *wsConn) (context.Context, error) {
@@ -86,6 +89,11 @@ func WithReverseClient[RP any](namespace string) ServerOption {
 	}
 }
 
+// ExtractReverseClient will extract reverse client from context. Reverse client for the type
+// will only be present if the server was constructed with a matching WithReverseClient option
+// and the connection was a websocket connection.
+// If there is no reverse client, the call will return a zero value and `false`. Otherwise a reverse
+// client and `true` will be returned.
 func ExtractReverseClient[C any](ctx context.Context) (C, bool) {
 	c, ok := ctx.Value(jsonrpcReverseClient{reflect.TypeOf(new(C)).Elem()}).(*C)
 	if !ok {

--- a/options_server.go
+++ b/options_server.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"reflect"
 	"time"
+
+	"golang.org/x/xerrors"
 )
+
+type jsonrpcReverseClient struct{ reflect.Type }
 
 type ParamDecoder func(ctx context.Context, json []byte) (reflect.Value, error)
 
@@ -14,6 +18,8 @@ type ServerConfig struct {
 
 	paramDecoders map[reflect.Type]ParamDecoder
 	errors        *Errors
+
+	reverseClientBuilder func(context.Context, *wsConn) (context.Context, error)
 }
 
 type ServerOption func(c *ServerConfig)
@@ -49,4 +55,46 @@ func WithServerPingInterval(d time.Duration) ServerOption {
 	return func(c *ServerConfig) {
 		c.pingInterval = d
 	}
+}
+
+func WithReverseClient[RP any](namespace string) ServerOption {
+	return func(c *ServerConfig) {
+		c.reverseClientBuilder = func(ctx context.Context, conn *wsConn) (context.Context, error) {
+			cl := client{
+				namespace:     namespace,
+				paramEncoders: map[reflect.Type]ParamEncoder{},
+			}
+
+			// todo test that everything is closing correctly
+			stop := make(chan struct{}) // todo better stop?
+			cl.exiting = stop
+
+			requests := cl.setup()
+			conn.requests = requests
+
+			calls := new(RP)
+
+			err := cl.provide([]interface{}{
+				calls,
+			})
+			if err != nil {
+				return nil, xerrors.Errorf("provide reverse client calls: %w", err)
+			}
+
+			return context.WithValue(ctx, jsonrpcReverseClient{reflect.TypeOf(calls).Elem()}, calls), nil
+		}
+	}
+}
+
+func ExtractReverseClient[C any](ctx context.Context) (C, bool) {
+	c, ok := ctx.Value(jsonrpcReverseClient{reflect.TypeOf(new(C)).Elem()}).(*C)
+	if !ok {
+		return *new(C), false
+	}
+	if c == nil {
+		// something is very wrong, but don't panic
+		return *new(C), false
+	}
+
+	return *c, ok
 }

--- a/server.go
+++ b/server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"time"
 
@@ -20,19 +19,10 @@ const (
 
 // RPCServer provides a jsonrpc 2.0 http server handler
 type RPCServer struct {
-	methods map[string]rpcHandler
-	errors  *Errors
-
-	// aliasedMethods contains a map of alias:original method names.
-	// These are used as fallbacks if a method is not found by the given method name.
-	aliasedMethods map[string]string
-
-	paramDecoders map[reflect.Type]ParamDecoder
-
+	*handler
 	reverseClientBuilder func(context.Context, *wsConn) (context.Context, error)
 
 	pingInterval   time.Duration
-	maxRequestSize int64
 }
 
 // NewServer creates new RPCServer instance
@@ -43,12 +33,8 @@ func NewServer(opts ...ServerOption) *RPCServer {
 	}
 
 	return &RPCServer{
-		methods:              map[string]rpcHandler{},
-		aliasedMethods:       map[string]string{},
-		paramDecoders:        config.paramDecoders,
+		handler:              makeHandler(config),
 		reverseClientBuilder: config.reverseClientBuilder,
-		maxRequestSize:       config.maxRequestSize,
-		errors:               config.errors,
 
 		pingInterval: config.pingInterval,
 	}

--- a/server.go
+++ b/server.go
@@ -22,7 +22,7 @@ type RPCServer struct {
 	*handler
 	reverseClientBuilder func(context.Context, *wsConn) (context.Context, error)
 
-	pingInterval   time.Duration
+	pingInterval time.Duration
 }
 
 // NewServer creates new RPCServer instance

--- a/websocket.go
+++ b/websocket.go
@@ -45,6 +45,10 @@ type outChanReg struct {
 	ch   reflect.Value
 }
 
+type reqestHandler interface {
+	handle(ctx context.Context, req request, w func(func(io.Writer)), rpcError rpcErrFunc, done func(keepCtx bool), chOut chanOut)
+}
+
 type wsConn struct {
 	// outside params
 	conn             *websocket.Conn
@@ -52,7 +56,7 @@ type wsConn struct {
 	reconnectBackoff backoff
 	pingInterval     time.Duration
 	timeout          time.Duration
-	handler          *RPCServer
+	handler          reqestHandler
 	requests         <-chan clientRequest
 	pongs            chan struct{}
 	stopPings        func()

--- a/websocket.go
+++ b/websocket.go
@@ -386,7 +386,7 @@ func (c *wsConn) handleResponse(frame frame) {
 
 func (c *wsConn) handleCall(ctx context.Context, frame frame) {
 	if c.handler == nil {
-		log.Error("handleCall on client")
+		log.Error("handleCall on client with no reverse handler")
 		return
 	}
 


### PR DESCRIPTION
* Support making calls from server side
* Support handling server calls on the client side
* Support renaming client calls
* Support sending notifications
* Support sending/receiving params with non-array serialization

All of the above is needed to make it possible to implement / consume `eth_subscribe` correctly with this library.

See rpc_test.go for usage examples.