### PR TITLE
Harden websocket loop

### DIFF
--- a/options_server.go
+++ b/options_server.go
@@ -3,14 +3,17 @@ package jsonrpc
 import (
 	"context"
 	"reflect"
+	"time"
 )
 
 type ParamDecoder func(ctx context.Context, json []byte) (reflect.Value, error)
 
 type ServerConfig struct {
-	paramDecoders  map[reflect.Type]ParamDecoder
 	maxRequestSize int64
-	errors         *Errors
+	pingInterval   time.Duration
+
+	paramDecoders map[reflect.Type]ParamDecoder
+	errors        *Errors
 }
 
 type ServerOption func(c *ServerConfig)
@@ -19,6 +22,8 @@ func defaultServerConfig() ServerConfig {
 	return ServerConfig{
 		paramDecoders:  map[reflect.Type]ParamDecoder{},
 		maxRequestSize: DEFAULT_MAX_REQUEST_SIZE,
+
+		pingInterval: 5 * time.Second,
 	}
 }
 
@@ -37,5 +42,11 @@ func WithMaxRequestSize(max int64) ServerOption {
 func WithServerErrors(es Errors) ServerOption {
 	return func(c *ServerConfig) {
 		c.errors = &es
+	}
+}
+
+func WithServerPingInterval(d time.Duration) ServerOption {
+	return func(c *ServerConfig) {
+		c.pingInterval = d
 	}
 }

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -27,6 +27,8 @@ func init() {
 	if err := logging.SetLogLevel("rpc", "DEBUG"); err != nil {
 		panic(err)
 	}
+
+	debugTrace = true
 }
 
 type SimpleServerHandler struct {

--- a/server.go
+++ b/server.go
@@ -67,8 +67,8 @@ func (s *RPCServer) handleWS(ctx context.Context, w http.ResponseWriter, r *http
 
 	c, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Error(err)
-		w.WriteHeader(500)
+		log.Errorw("upgrading connection", "error", err)
+		// note that upgrader.Upgrade will set http error if there is an error
 		return
 	}
 
@@ -80,7 +80,7 @@ func (s *RPCServer) handleWS(ctx context.Context, w http.ResponseWriter, r *http
 	}).handleWsConn(ctx)
 
 	if err := c.Close(); err != nil {
-		log.Error(err)
+		log.Errorw("closing websocket connection", "error", err)
 		return
 	}
 }

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -28,6 +29,7 @@ type RPCServer struct {
 
 	paramDecoders map[reflect.Type]ParamDecoder
 
+	pingInterval   time.Duration
 	maxRequestSize int64
 }
 
@@ -44,6 +46,8 @@ func NewServer(opts ...ServerOption) *RPCServer {
 		paramDecoders:  config.paramDecoders,
 		maxRequestSize: config.maxRequestSize,
 		errors:         config.errors,
+
+		pingInterval: config.pingInterval,
 	}
 }
 
@@ -69,9 +73,10 @@ func (s *RPCServer) handleWS(ctx context.Context, w http.ResponseWriter, r *http
 	}
 
 	(&wsConn{
-		conn:    c,
-		handler: s,
-		exiting: make(chan struct{}),
+		conn:         c,
+		handler:      s,
+		pingInterval: s.pingInterval,
+		exiting:      make(chan struct{}),
 	}).handleWsConn(ctx)
 
 	if err := c.Close(); err != nil {


### PR DESCRIPTION
This PR:
* Enables sending pings from the server side
  * If the theory that the connection drops are caused by the server loop being stuck/slow is correct, this should fix that issue (pings are sent from a separate goroutine)
* Makes received pings reset deadlines
* Adds a warning log when there is no activity for some time (>2x ping interval)
* Adds an extremely verbose debug mode
  * Enabled by setting the `rpc` subsystem log level to debug and setting `JSONRPC_ENABLE_DEBUG_TRACE=1`

Aims to fix, or at least aid in fixing https://github.com/filecoin-project/lotus/issues/9988 / related issues