### PR TITLE
feat: Add custom delimiter to ServerOptions

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,10 +94,10 @@ func NewClient(ctx context.Context, addr string, namespace string, handler inter
 }
 
 type client struct {
-	namespace     string
-	delimiter     string
-	paramEncoders map[reflect.Type]ParamEncoder
-	errors        *Errors
+	namespace          string
+	namespaceDelimiter string
+	paramEncoders      map[reflect.Type]ParamEncoder
+	errors             *Errors
 
 	doRequest func(context.Context, clientRequest) (clientResponse, error)
 	exiting   <-chan struct{}
@@ -130,10 +130,10 @@ func NewMergeClient(ctx context.Context, addr string, namespace string, outs []i
 
 func httpClient(ctx context.Context, addr string, namespace string, outs []interface{}, requestHeader http.Header, config Config) (ClientCloser, error) {
 	c := client{
-		namespace:     namespace,
-		delimiter:     config.namespaceDelimiter,
-		paramEncoders: config.paramEncoders,
-		errors:        config.errors,
+		namespace:          namespace,
+		namespaceDelimiter: config.namespaceDelimiter,
+		paramEncoders:      config.paramEncoders,
+		errors:             config.errors,
 	}
 
 	stop := make(chan struct{})
@@ -219,10 +219,10 @@ func websocketClient(ctx context.Context, addr string, namespace string, outs []
 	}
 
 	c := client{
-		namespace:     namespace,
-		delimiter:     config.namespaceDelimiter,
-		paramEncoders: config.paramEncoders,
-		errors:        config.errors,
+		namespace:          namespace,
+		namespaceDelimiter: config.namespaceDelimiter,
+		paramEncoders:      config.paramEncoders,
+		errors:             config.errors,
 	}
 
 	requests := c.setupRequestChan()
@@ -236,7 +236,7 @@ func websocketClient(ctx context.Context, addr string, namespace string, outs []
 		h := makeHandler(defaultServerConfig())
 		h.aliasedMethods = config.aliasedHandlerMethods
 		for _, reverseHandler := range config.reverseHandlers {
-			h.register(reverseHandler.ns, c.delimiter, reverseHandler.hnd)
+			h.register(reverseHandler.ns, c.namespaceDelimiter, reverseHandler.hnd)
 		}
 		hnd = h
 	}
@@ -636,7 +636,7 @@ func (c *client) makeRpcFunc(f reflect.StructField) (reflect.Value, error) {
 		return reflect.Value{}, xerrors.New("handler field not a func")
 	}
 
-	name := c.namespace + c.delimiter + f.Name
+	name := c.namespace + c.namespaceDelimiter + f.Name
 	if tag, ok := f.Tag.Lookup(ProxyTagRPCMethod); ok {
 		name = tag
 	}

--- a/client.go
+++ b/client.go
@@ -131,7 +131,7 @@ func NewMergeClient(ctx context.Context, addr string, namespace string, outs []i
 func httpClient(ctx context.Context, addr string, namespace string, outs []interface{}, requestHeader http.Header, config Config) (ClientCloser, error) {
 	c := client{
 		namespace:     namespace,
-		delimiter:     config.namespacedelimiter,
+		delimiter:     config.namespaceDelimiter,
 		paramEncoders: config.paramEncoders,
 		errors:        config.errors,
 	}
@@ -220,7 +220,7 @@ func websocketClient(ctx context.Context, addr string, namespace string, outs []
 
 	c := client{
 		namespace:     namespace,
-		delimiter:     config.namespacedelimiter,
+		delimiter:     config.namespaceDelimiter,
 		paramEncoders: config.paramEncoders,
 		errors:        config.errors,
 	}

--- a/client.go
+++ b/client.go
@@ -95,7 +95,7 @@ func NewClient(ctx context.Context, addr string, namespace string, handler inter
 
 type client struct {
 	namespace     string
-	delimeter     string
+	delimiter     string
 	paramEncoders map[reflect.Type]ParamEncoder
 	errors        *Errors
 
@@ -131,7 +131,7 @@ func NewMergeClient(ctx context.Context, addr string, namespace string, outs []i
 func httpClient(ctx context.Context, addr string, namespace string, outs []interface{}, requestHeader http.Header, config Config) (ClientCloser, error) {
 	c := client{
 		namespace:     namespace,
-		delimeter:     config.namespaceDelimeter,
+		delimiter:     config.namespacedelimiter,
 		paramEncoders: config.paramEncoders,
 		errors:        config.errors,
 	}
@@ -220,7 +220,7 @@ func websocketClient(ctx context.Context, addr string, namespace string, outs []
 
 	c := client{
 		namespace:     namespace,
-		delimeter:     config.namespaceDelimeter,
+		delimiter:     config.namespacedelimiter,
 		paramEncoders: config.paramEncoders,
 		errors:        config.errors,
 	}
@@ -236,7 +236,7 @@ func websocketClient(ctx context.Context, addr string, namespace string, outs []
 		h := makeHandler(defaultServerConfig())
 		h.aliasedMethods = config.aliasedHandlerMethods
 		for _, reverseHandler := range config.reverseHandlers {
-			h.register(reverseHandler.ns, c.delimeter, reverseHandler.hnd)
+			h.register(reverseHandler.ns, c.delimiter, reverseHandler.hnd)
 		}
 		hnd = h
 	}
@@ -636,7 +636,7 @@ func (c *client) makeRpcFunc(f reflect.StructField) (reflect.Value, error) {
 		return reflect.Value{}, xerrors.New("handler field not a func")
 	}
 
-	name := c.namespace + c.delimeter + f.Name
+	name := c.namespace + c.delimiter + f.Name
 	if tag, ok := f.Tag.Lookup(ProxyTagRPCMethod); ok {
 		name = tag
 	}

--- a/handler.go
+++ b/handler.go
@@ -115,10 +115,9 @@ type handler struct {
 	errors  *Errors
 
 	maxRequestSize int64
-
+	delimiter      string
 	// aliasedMethods contains a map of alias:original method names.
 	// These are used as fallbacks if a method is not found by the given method name.
-	delimiter      string
 	aliasedMethods map[string]string
 
 	paramDecoders map[reflect.Type]ParamDecoder
@@ -126,9 +125,9 @@ type handler struct {
 
 func makeHandler(sc ServerConfig) *handler {
 	return &handler{
-		methods: make(map[string]methodHandler),
-		errors:  sc.errors,
-
+		methods:        make(map[string]methodHandler),
+		errors:         sc.errors,
+		delimiter:      sc.namespaceDelimiter,
 		aliasedMethods: map[string]string{},
 		paramDecoders:  sc.paramDecoders,
 

--- a/handler.go
+++ b/handler.go
@@ -118,6 +118,7 @@ type handler struct {
 
 	// aliasedMethods contains a map of alias:original method names.
 	// These are used as fallbacks if a method is not found by the given method name.
+	delimiter      string
 	aliasedMethods map[string]string
 
 	paramDecoders map[reflect.Type]ParamDecoder
@@ -137,7 +138,7 @@ func makeHandler(sc ServerConfig) *handler {
 
 // Register
 
-func (s *handler) register(namespace string, r interface{}) {
+func (s *handler) register(namespace string, delimiter string, r interface{}) {
 	val := reflect.ValueOf(r)
 	// TODO: expect ptr
 
@@ -165,7 +166,7 @@ func (s *handler) register(namespace string, r interface{}) {
 
 		valOut, errOut, _ := processFuncOut(funcType)
 
-		s.methods[namespace+"."+method.Name] = methodHandler{
+		s.methods[namespace+delimiter+method.Name] = methodHandler{
 			paramReceivers: recvs,
 			nParams:        ins,
 

--- a/options.go
+++ b/options.go
@@ -24,7 +24,7 @@ type Config struct {
 	errors        *Errors
 
 	reverseHandlers       []clientHandler
-	namespaceDelimeter    string
+	namespacedelimiter    string
 	aliasedHandlerMethods map[string]string
 
 	httpClient *http.Client
@@ -42,7 +42,7 @@ func defaultConfig() Config {
 		pingInterval: 5 * time.Second,
 		timeout:      30 * time.Second,
 
-		namespaceDelimeter:    ".",
+		namespacedelimiter:    ".",
 		aliasedHandlerMethods: map[string]string{},
 
 		paramEncoders: map[reflect.Type]ParamEncoder{},

--- a/options.go
+++ b/options.go
@@ -24,6 +24,7 @@ type Config struct {
 	errors        *Errors
 
 	reverseHandlers       []clientHandler
+	namespaceDelimeter    string
 	aliasedHandlerMethods map[string]string
 
 	httpClient *http.Client
@@ -41,6 +42,7 @@ func defaultConfig() Config {
 		pingInterval: 5 * time.Second,
 		timeout:      30 * time.Second,
 
+		namespaceDelimeter:    ".",
 		aliasedHandlerMethods: map[string]string{},
 
 		paramEncoders: map[reflect.Type]ParamEncoder{},

--- a/options.go
+++ b/options.go
@@ -24,7 +24,7 @@ type Config struct {
 	errors        *Errors
 
 	reverseHandlers       []clientHandler
-	namespacedelimiter    string
+	namespaceDelimiter    string
 	aliasedHandlerMethods map[string]string
 
 	httpClient *http.Client
@@ -42,7 +42,7 @@ func defaultConfig() Config {
 		pingInterval: 5 * time.Second,
 		timeout:      30 * time.Second,
 
-		namespacedelimiter:    ".",
+		namespaceDelimiter:    ".",
 		aliasedHandlerMethods: map[string]string{},
 
 		paramEncoders: map[reflect.Type]ParamEncoder{},

--- a/options_server.go
+++ b/options_server.go
@@ -14,8 +14,9 @@ type jsonrpcReverseClient struct{ reflect.Type }
 type ParamDecoder func(ctx context.Context, json []byte) (reflect.Value, error)
 
 type ServerConfig struct {
-	maxRequestSize int64
-	pingInterval   time.Duration
+	maxRequestSize     int64
+	pingInterval       time.Duration
+	namespaceDelimiter string
 
 	paramDecoders map[reflect.Type]ParamDecoder
 	errors        *Errors
@@ -27,10 +28,10 @@ type ServerOption func(c *ServerConfig)
 
 func defaultServerConfig() ServerConfig {
 	return ServerConfig{
-		paramDecoders:  map[reflect.Type]ParamDecoder{},
-		maxRequestSize: DEFAULT_MAX_REQUEST_SIZE,
-
-		pingInterval: 5 * time.Second,
+		paramDecoders:      map[reflect.Type]ParamDecoder{},
+		maxRequestSize:     DEFAULT_MAX_REQUEST_SIZE,
+		namespaceDelimiter: ".",
+		pingInterval:       5 * time.Second,
 	}
 }
 
@@ -64,8 +65,9 @@ func WithReverseClient[RP any](namespace string) ServerOption {
 	return func(c *ServerConfig) {
 		c.reverseClientBuilder = func(ctx context.Context, conn *wsConn) (context.Context, error) {
 			cl := client{
-				namespace:     namespace,
-				paramEncoders: map[reflect.Type]ParamEncoder{},
+				namespace:          namespace,
+				namespaceDelimiter: c.namespaceDelimiter,
+				paramEncoders:      map[reflect.Type]ParamEncoder{},
 			}
 
 			// todo test that everything is closing correctly

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1360,7 +1360,6 @@ func TestReverseCallAliased(t *testing.T) {
 	defer testServ.Close()
 
 	// setup client
-
 	var client struct {
 		Call func() error
 	}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1360,6 +1360,7 @@ func TestReverseCallAliased(t *testing.T) {
 	defer testServ.Close()
 
 	// setup client
+
 	var client struct {
 		Call func() error
 	}

--- a/server.go
+++ b/server.go
@@ -132,7 +132,7 @@ func rpcError(wf func(func(io.Writer)), req *request, code ErrorCode, err error)
 //
 // Handler is any value with methods defined
 func (s *RPCServer) Register(namespace string, handler interface{}) {
-	s.register(namespace, handler)
+	s.register(namespace, s.handler.delimiter, handler)
 }
 
 func (s *RPCServer) AliasMethod(alias, original string) {


### PR DESCRIPTION
Increase reusability of the library but allowing users to add a custom delimiter opposed to enforcing the use of `.`.

Example use case, conforming to `eth_xxxxx`