### PR TITLE
fix: Handle missing params field correctly

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -338,11 +338,13 @@ func (s *handler) handle(ctx context.Context, req request, w func(func(io.Writer
 		// "normal" param list; no good way to do named params in Golang
 
 		var ps []param
-		err := json.Unmarshal(req.Params, &ps)
-		if err != nil {
-			rpcError(w, &req, rpcParseError, xerrors.Errorf("unmarshaling param array: %w", err))
-			stats.Record(ctx, metrics.RPCRequestError.M(1))
-			return
+		if len(req.Params) > 0 {
+			err := json.Unmarshal(req.Params, &ps)
+			if err != nil {
+				rpcError(w, &req, rpcParseError, xerrors.Errorf("unmarshaling param array: %w", err))
+				stats.Record(ctx, metrics.RPCRequestError.M(1))
+				return
+			}
 		}
 
 		if len(ps) != handler.nParams {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strconv"
@@ -45,6 +46,12 @@ type TestOut struct {
 	Ok bool
 }
 
+func (h *SimpleServerHandler) Inc() error {
+	h.n++
+
+	return nil
+}
+
 func (h *SimpleServerHandler) Add(in int) error {
 	if in == -3546 {
 		return errors.New("test")
@@ -70,6 +77,36 @@ func (h *SimpleServerHandler) StringMatch(t TestType, i2 int64) (out TestOut, er
 	out.I = t.I
 	out.S = t.S
 	return
+}
+
+func TestRawRequests(t *testing.T) {
+	rpcHandler := SimpleServerHandler{}
+
+	rpcServer := NewServer()
+	rpcServer.Register("SimpleServerHandler", &rpcHandler)
+
+	testServ := httptest.NewServer(rpcServer)
+	defer testServ.Close()
+
+	tc := func(req, resp string, n int) func(t *testing.T) {
+		return func(t *testing.T) {
+			rpcHandler.n = 0
+
+			res, err := http.Post(testServ.URL, "application/json", strings.NewReader(req))
+			require.NoError(t, err)
+
+			b, err := ioutil.ReadAll(res.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, resp, strings.TrimSpace(string(b)))
+			require.Equal(t, n, rpcHandler.n)
+		}
+	}
+
+	t.Run("inc", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": [], "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1))
+	t.Run("inc-noparam", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "id": 2}`, `{"jsonrpc":"2.0","id":2}`, 1))
+	t.Run("add", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [10], "id": 4}`, `{"jsonrpc":"2.0","id":4}`, 10))
+
 }
 
 func TestReconnection(t *testing.T) {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -104,6 +104,7 @@ func TestRawRequests(t *testing.T) {
 	}
 
 	t.Run("inc", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": [], "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1))
+	t.Run("inc-null", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": null, "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1))
 	t.Run("inc-noparam", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "id": 2}`, `{"jsonrpc":"2.0","id":2}`, 1))
 	t.Run("add", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [10], "id": 4}`, `{"jsonrpc":"2.0","id":4}`, 10))
 


### PR DESCRIPTION
Omitting the params field is allowed when the method takes no params.