### PR TITLE
Fix reverse client hang on closed connections

### DIFF
--- a/options_server.go
+++ b/options_server.go
@@ -69,8 +69,7 @@ func WithReverseClient[RP any](namespace string) ServerOption {
 			}
 
 			// todo test that everything is closing correctly
-			stop := make(chan struct{}) // todo better stop?
-			cl.exiting = stop
+			cl.exiting = conn.exiting
 
 			requests := cl.setupRequestChan()
 			conn.requests = requests


### PR DESCRIPTION
Partially addresses https://github.com/filecoin-project/lotus/issues/10484