### PR TITLE
feat: add batch request support

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -222,11 +222,11 @@ func (s *handler) handleReader(ctx context.Context, r io.Reader, w io.Writer, rp
 		return
 	}
 
-	if bufferedRequest.Bytes()[0] == '[' {
+	if bufferedRequest.Bytes()[0] == '[' && bufferedRequest.Bytes()[reqSize-1] == ']' {
 		var reqs []request
 
 		if err := json.NewDecoder(bufferedRequest).Decode(&reqs); err != nil {
-			rpcError(wf, nil, rpcParseError, xerrors.Errorf("Parse error: %w", err))
+			rpcError(wf, nil, rpcParseError, xerrors.New("Parse error"))
 			return
 		}
 
@@ -252,7 +252,7 @@ func (s *handler) handleReader(ctx context.Context, r io.Reader, w io.Writer, rp
 	} else {
 		var req request
 		if err := json.NewDecoder(bufferedRequest).Decode(&req); err != nil {
-			rpcError(wf, &req, rpcParseError, xerrors.Errorf("Parse error: %w", err))
+			rpcError(wf, &req, rpcParseError, xerrors.New("Parse error"))
 			return
 		}
 

--- a/handler.go
+++ b/handler.go
@@ -191,7 +191,6 @@ func (s *handler) handleReader(ctx context.Context, r io.Reader, w io.Writer, rp
 		cb(w)
 	}
 
-	var req request
 	// We read the entire request upfront in a buffer to be able to tell if the
 	// client sent more than maxRequestSize and report it back as an explicit error,
 	// instead of just silently truncating it and reporting a more vague parsing
@@ -205,11 +204,11 @@ func (s *handler) handleReader(ctx context.Context, r io.Reader, w io.Writer, rp
 	if err != nil {
 		// ReadFrom will discard EOF so any error here is unexpected and should
 		// be reported.
-		rpcError(wf, &req, rpcParseError, xerrors.Errorf("reading request: %w", err))
+		rpcError(wf, nil, rpcParseError, xerrors.Errorf("reading request: %w", err))
 		return
 	}
 	if reqSize > s.maxRequestSize {
-		rpcError(wf, &req, rpcParseError,
+		rpcError(wf, nil, rpcParseError,
 			// rpcParseError is the closest we have from the standard errors defined
 			// in [jsonrpc spec](https://www.jsonrpc.org/specification#error_object)
 			// to report the maximum limit.
@@ -218,17 +217,52 @@ func (s *handler) handleReader(ctx context.Context, r io.Reader, w io.Writer, rp
 		return
 	}
 
-	if err := json.NewDecoder(bufferedRequest).Decode(&req); err != nil {
-		rpcError(wf, &req, rpcParseError, xerrors.Errorf("unmarshaling request: %w", err))
+	if reqSize == 0 {
+		rpcError(wf, nil, rpcInvalidRequest, xerrors.New("Invalid request"))
 		return
 	}
 
-	if req.ID, err = normalizeID(req.ID); err != nil {
-		rpcError(wf, &req, rpcParseError, xerrors.Errorf("failed to parse ID: %w", err))
-		return
-	}
+	if bufferedRequest.Bytes()[0] == '[' {
+		var reqs []request
 
-	s.handle(ctx, req, wf, rpcError, func(bool) {}, nil)
+		if err := json.NewDecoder(bufferedRequest).Decode(&reqs); err != nil {
+			rpcError(wf, nil, rpcParseError, xerrors.Errorf("Parse error: %w", err))
+			return
+		}
+
+		if len(reqs) == 0 {
+			rpcError(wf, nil, rpcInvalidRequest, xerrors.New("Invalid request"))
+			return
+		}
+
+		w.Write([]byte("["))
+		for idx, req := range reqs {
+			if req.ID, err = normalizeID(req.ID); err != nil {
+				rpcError(wf, &req, rpcParseError, xerrors.Errorf("failed to parse ID: %w", err))
+				return
+			}
+
+			s.handle(ctx, req, wf, rpcError, func(bool) {}, nil)
+
+			if idx != len(reqs)-1 {
+				w.Write([]byte(","))
+			}
+		}
+		w.Write([]byte("]"))
+	} else {
+		var req request
+		if err := json.NewDecoder(bufferedRequest).Decode(&req); err != nil {
+			rpcError(wf, &req, rpcParseError, xerrors.Errorf("Parse error: %w", err))
+			return
+		}
+
+		if req.ID, err = normalizeID(req.ID); err != nil {
+			rpcError(wf, &req, rpcParseError, xerrors.Errorf("failed to parse ID: %w", err))
+			return
+		}
+
+		s.handle(ctx, req, wf, rpcError, func(bool) {}, nil)
+	}
 }
 
 func doCall(methodName string, f reflect.Value, params []reflect.Value) (out []reflect.Value, err error) {

--- a/handler.go
+++ b/handler.go
@@ -217,6 +217,10 @@ func (s *handler) handleReader(ctx context.Context, r io.Reader, w io.Writer, rp
 		return
 	}
 
+	// Trim spaces to avoid issues with batch request detection.
+	bufferedRequest = bytes.NewBuffer(bytes.TrimSpace(bufferedRequest.Bytes()))
+	reqSize = int64(bufferedRequest.Len())
+
 	if reqSize == 0 {
 		rpcError(wf, nil, rpcInvalidRequest, xerrors.New("Invalid request"))
 		return

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -105,7 +105,7 @@ func TestRawRequests(t *testing.T) {
 		return string(compactJSONBytes), nil
 	}
 
-	tc := func(req, resp string, n int32) func(t *testing.T) {
+	tc := func(req, resp string, n int32, statusCode int) func(t *testing.T) {
 		return func(t *testing.T) {
 			rpcHandler.n = 0
 
@@ -123,18 +123,21 @@ func TestRawRequests(t *testing.T) {
 
 			assert.Equal(t, expectedResp, responseBody)
 			require.Equal(t, n, rpcHandler.n)
+			require.Equal(t, statusCode, res.StatusCode)
 		}
 	}
 
-	t.Run("inc", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": [], "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1))
-	t.Run("inc-null", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": null, "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1))
-	t.Run("inc-noparam", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "id": 2}`, `{"jsonrpc":"2.0","id":2}`, 1))
-	t.Run("add", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [10], "id": 4}`, `{"jsonrpc":"2.0","id":4}`, 10))
+	t.Run("inc", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": [], "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1, 200))
+	t.Run("inc-null", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": null, "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1, 200))
+	t.Run("inc-noparam", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "id": 2}`, `{"jsonrpc":"2.0","id":2}`, 1, 200))
+	t.Run("add", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [10], "id": 4}`, `{"jsonrpc":"2.0","id":4}`, 10, 200))
 	// Batch requests
-	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 5}`, `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}`, 0))
-	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 6}]`, `[{"jsonrpc":"2.0","id":6}]`, 123))
-	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 7},{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [-122], "id": 8}]`, `[{"jsonrpc":"2.0","id":7},{"jsonrpc":"2.0","id":8}]`, 1))
-	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 9},{"jsonrpc": "2.0", "params": [-122], "id": 10}]`, `[{"jsonrpc":"2.0","id":9},{"error":{"code":-32601,"message":"method '' not found"},"id":10,"jsonrpc":"2.0"}]`, 123))
+	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 5}`, `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}`, 0, 500))
+	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 6}]`, `[{"jsonrpc":"2.0","id":6}]`, 123, 200))
+	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 7},{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [-122], "id": 8}]`, `[{"jsonrpc":"2.0","id":7},{"jsonrpc":"2.0","id":8}]`, 1, 200))
+	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 9},{"jsonrpc": "2.0", "params": [-122], "id": 10}]`, `[{"jsonrpc":"2.0","id":9},{"error":{"code":-32601,"message":"method '' not found"},"id":10,"jsonrpc":"2.0"}]`, 123, 200))
+	t.Run("add", tc(`     [{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [-1], "id": 11}]   `, `[{"jsonrpc":"2.0","id":11}]`, -1, 200))
+	t.Run("add", tc(``, `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid request"}}`, 0, 400))
 }
 
 func TestReconnection(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -108,7 +108,11 @@ func rpcError(wf func(func(io.Writer)), req *request, code ErrorCode, err error)
 	log.Errorf("RPC Error: %s", err)
 	wf(func(w io.Writer) {
 		if hw, ok := w.(http.ResponseWriter); ok {
-			hw.WriteHeader(200)
+			if code == rpcInvalidRequest {
+				hw.WriteHeader(400)
+			} else {
+				hw.WriteHeader(500)
+			}
 		}
 
 		log.Warnf("rpc error: %s", err)

--- a/server.go
+++ b/server.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	rpcParseError     = -32700
+	rpcInvalidRequest = -32600
 	rpcMethodNotFound = -32601
 	rpcInvalidParams  = -32602
 )
@@ -107,13 +108,13 @@ func rpcError(wf func(func(io.Writer)), req *request, code ErrorCode, err error)
 	log.Errorf("RPC Error: %s", err)
 	wf(func(w io.Writer) {
 		if hw, ok := w.(http.ResponseWriter); ok {
-			hw.WriteHeader(500)
+			hw.WriteHeader(200)
 		}
 
 		log.Warnf("rpc error: %s", err)
 
-		if req.ID == nil { // notification
-			return
+		if req == nil {
+			req = &request{}
 		}
 
 		resp := response{


### PR DESCRIPTION
This pull request adds support for batched requests in JSON-RPC v2 as described in the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification#batch).

### Changes:
* Add a check in  a new handleReader function to handle batched requests.
* Change in rpcError function response status code to 200. JSON-RPC errors are part of response body.
* Add new unit tests to cover batched request processing.

### Motivation:
Batched requests allow clients to send multiple requests in a single HTTP request, reducing overhead and allowing for more efficient communication. This is particularly useful in situations where multiple requests need to be made in a short period of time, such as when syncing data in real time.

### Testing:
New unit tests have been added to cover the processing of batched requests. Additionally, manual testing has been performed to ensure that the implementation correctly handles a variety of batched request scenarios, including valid and invalid inputs.

Please provide any feedback or suggestions for improvement.