### PR TITLE
 Fix a number of races in websocket channel code paths 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - checkout
       - run: go test -v -timeout 10m ./...
+  test-race:
+    executor: golang
+    steps:
+      - checkout
+      - run: go test -race -v -timeout 10m ./...
   mod-tidy-check:
     executor: golang
     steps:
@@ -42,3 +47,4 @@ workflows:
       - lint-check
       - gofmt-check
       - test
+      - test-race

--- a/handler.go
+++ b/handler.go
@@ -239,7 +239,7 @@ func (s *handler) handleReader(ctx context.Context, r io.Reader, w io.Writer, rp
 			return
 		}
 
-		w.Write([]byte("["))
+		_, _ = w.Write([]byte("[")) // todo consider handling this error
 		for idx, req := range reqs {
 			if req.ID, err = normalizeID(req.ID); err != nil {
 				rpcError(wf, &req, rpcParseError, xerrors.Errorf("failed to parse ID: %w", err))
@@ -249,10 +249,10 @@ func (s *handler) handleReader(ctx context.Context, r io.Reader, w io.Writer, rp
 			s.handle(ctx, req, wf, rpcError, func(bool) {}, nil)
 
 			if idx != len(reqs)-1 {
-				w.Write([]byte(","))
+				_, _ = w.Write([]byte(",")) // todo consider handling this error
 			}
 		}
-		w.Write([]byte("]"))
+		_, _ = w.Write([]byte("]")) // todo consider handling this error
 	} else {
 		var req request
 		if err := json.NewDecoder(bufferedRequest).Decode(&req); err != nil {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -160,16 +160,16 @@ func TestReconnection(t *testing.T) {
 	timer := time.NewTimer(captureDuration)
 
 	// record the number of connection attempts during this test
-	connectionAttempts := 1
+	connectionAttempts := int64(1)
 
 	closer, err := NewMergeClient(context.Background(), "ws://"+testServ.Listener.Addr().String(), "SimpleServerHandler", []interface{}{&rpcClient}, nil, func(c *Config) {
 		c.proxyConnFactory = func(f func() (*websocket.Conn, error)) func() (*websocket.Conn, error) {
 			return func() (*websocket.Conn, error) {
 				defer func() {
-					connectionAttempts++
+					atomic.AddInt64(&connectionAttempts, 1)
 				}()
 
-				if connectionAttempts > 1 {
+				if atomic.LoadInt64(&connectionAttempts) > 1 {
 					return nil, errors.New("simulates a failed reconnect attempt")
 				}
 
@@ -192,7 +192,7 @@ func TestReconnection(t *testing.T) {
 	<-timer.C
 
 	// do some math
-	attemptsPerSecond := int64(connectionAttempts) / int64(captureDuration/time.Second)
+	attemptsPerSecond := atomic.LoadInt64(&connectionAttempts) / int64(captureDuration/time.Second)
 
 	assert.Less(t, attemptsPerSecond, int64(50))
 }
@@ -677,7 +677,7 @@ func (h *ChanHandler) Sub(ctx context.Context, i int, eq int) (<-chan int, error
 				fmt.Println("ctxdone1", i, eq)
 				return
 			case <-wait:
-				fmt.Println("CONSUMED WAIT: ", i)
+				//fmt.Println("CONSUMED WAIT: ", i)
 			}
 
 			n += i
@@ -835,10 +835,11 @@ func TestChanServerClose(t *testing.T) {
 
 	tctx, tcancel := context.WithCancel(context.Background())
 
-	testServ := httptest.NewServer(rpcServer)
+	testServ := httptest.NewUnstartedServer(rpcServer)
 	testServ.Config.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
 		return tctx
 	}
+	testServ.Start()
 
 	closer, err := NewClient(context.Background(), "ws://"+testServ.Listener.Addr().String(), "ChanHandler", &client, nil)
 	require.NoError(t, err)
@@ -966,10 +967,11 @@ func TestChanClientReceiveAll(t *testing.T) {
 
 	tctx, tcancel := context.WithCancel(context.Background())
 
-	testServ := httptest.NewServer(rpcServer)
+	testServ := httptest.NewUnstartedServer(rpcServer)
 	testServ.Config.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
 		return tctx
 	}
+	testServ.Start()
 
 	closer, err := NewClient(context.Background(), "ws://"+testServ.Listener.Addr().String(), "ChanHandler", &client, nil)
 	require.NoError(t, err)
@@ -1005,6 +1007,9 @@ func TestChanClientReceiveAll(t *testing.T) {
 }
 
 func TestControlChanDeadlock(t *testing.T) {
+	logging.SetLogLevel("rpc", "error")
+	defer logging.SetLogLevel("rpc", "debug")
+
 	for r := 0; r < 20; r++ {
 		testControlChanDeadlock(t)
 	}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1007,8 +1007,10 @@ func TestChanClientReceiveAll(t *testing.T) {
 }
 
 func TestControlChanDeadlock(t *testing.T) {
-	logging.SetLogLevel("rpc", "error")
-	defer logging.SetLogLevel("rpc", "debug")
+	_ = logging.SetLogLevel("rpc", "error")
+	defer func() {
+		_ = logging.SetLogLevel("rpc", "debug")
+	}()
 
 	for r := 0; r < 20; r++ {
 		testControlChanDeadlock(t)


### PR DESCRIPTION
Fixes following races:
```
WARNING: DATA RACE
Read at 0x00c0001220b8 by goroutine 81038:
  github.com/filecoin-project/go-jsonrpc.(*wsConn).cancelCtx()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:355 +0x45a
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleFrame()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:517 +0xc4
  github.com/filecoin-project/go-jsonrpc.(*wsConn).frameExecutor()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:704 +0x52f
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleWsConn.func5()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:745 +0x58

Previous write at 0x00c0001220b8 by goroutine 81035:
  github.com/filecoin-project/go-jsonrpc.(*wsConn).closeInFlight()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:548 +0x393
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleWsConn.func2()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:730 +0x39
  runtime.deferreturn()
      /usr/lib/go/src/runtime/panic.go:476 +0x32
  github.com/filecoin-project/go-jsonrpc.(*RPCServer).handleWS.func1()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/server.go:84 +0x44
  runtime/pprof.Do()
      /usr/lib/go/src/runtime/pprof/runtime.go:44 +0x122
  github.com/filecoin-project/go-jsonrpc.(*RPCServer).handleWS()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/server.go:83 +0xb17
  github.com/filecoin-project/go-jsonrpc.(*RPCServer).ServeHTTP()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/server.go:99 +0x150
  net/http.serverHandler.ServeHTTP()
      /usr/lib/go/src/net/http/server.go:2936 +0x682
  net/http.(*conn).serve()
      /usr/lib/go/src/net/http/server.go:1995 +0xbd4
  net/http.(*Server).Serve.func3()
      /usr/lib/go/src/net/http/server.go:3089 +0x58

Goroutine 81038 (running) created at:
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleWsConn()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:745 +0x70d
  github.com/filecoin-project/go-jsonrpc.(*RPCServer).handleWS.func1()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/server.go:84 +0x44
  runtime/pprof.Do()
      /usr/lib/go/src/runtime/pprof/runtime.go:44 +0x122
  github.com/filecoin-project/go-jsonrpc.(*RPCServer).handleWS()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/server.go:83 +0xb17
  github.com/filecoin-project/go-jsonrpc.(*RPCServer).ServeHTTP()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/server.go:99 +0x150
  net/http.serverHandler.ServeHTTP()
      /usr/lib/go/src/net/http/server.go:2936 +0x682
  net/http.(*conn).serve()
      /usr/lib/go/src/net/http/server.go:1995 +0xbd4
  net/http.(*Server).Serve.func3()
      /usr/lib/go/src/net/http/server.go:3089 +0x58

Goroutine 81035 (running) created at:
  net/http.(*Server).Serve()
      /usr/lib/go/src/net/http/server.go:3089 +0x817
  net/http/httptest.(*Server).goServe.func1()
      /usr/lib/go/src/net/http/httptest/server.go:310 +0xbb
==================
```

```
Write at 0x00c0008385b0 by goroutine 140846:
  runtime.closechan()
      /usr/lib/go/src/runtime/chan.go:357 +0x0
  github.com/filecoin-project/go-jsonrpc.(*client).makeOutChan.func1.2()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:423 +0x444
  github.com/filecoin-project/go-jsonrpc.(*wsConn).closeChans()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:529 +0x141
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleWsConn.func3()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:693 +0x39
  runtime.deferreturn()
      /usr/lib/go/src/runtime/panic.go:476 +0x32
  github.com/filecoin-project/go-jsonrpc.websocketClient.func2.1()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:258 +0x44
  runtime/pprof.Do()
      /usr/lib/go/src/runtime/pprof/runtime.go:44 +0x122
  github.com/filecoin-project/go-jsonrpc.websocketClient.func2()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:257 +0x43b

Previous read at 0x00c0008385b0 by goroutine 140849:
  runtime.chansend()
      /usr/lib/go/src/runtime/chan.go:160 +0x0
  github.com/filecoin-project/go-jsonrpc.(*client).makeOutChan.func1.2()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:439 +0x3ca
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleChanMessage()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:376 +0x422
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleFrame()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:493 +0x124
  github.com/filecoin-project/go-jsonrpc.(*wsConn).frameExecutor()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:666 +0x52f
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleWsConn.func5()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:707 +0x58

Goroutine 140846 (running) created at:
  github.com/filecoin-project/go-jsonrpc.websocketClient()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:255 +0xa04
  github.com/filecoin-project/go-jsonrpc.NewMergeClient()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:123 +0x404
  github.com/filecoin-project/go-jsonrpc.NewClient()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:95 +0x2b2
  github.com/filecoin-project/go-jsonrpc.testControlChanDeadlock()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/rpc_test.go:1007 +0x1e5
  github.com/filecoin-project/go-jsonrpc.TestControlChanDeadlock()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/rpc_test.go:986 +0x8a
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/lib/go/src/testing/testing.go:1629 +0x47

Goroutine 140849 (running) created at:
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleWsConn()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/websocket.go:707 +0x70d
  github.com/filecoin-project/go-jsonrpc.websocketClient.func2.1()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:258 +0x44
  runtime/pprof.Do()
      /usr/lib/go/src/runtime/pprof/runtime.go:44 +0x122
  github.com/filecoin-project/go-jsonrpc.websocketClient.func2()
      /home/magik6k/gohack/github.com/filecoin-project/go-jsonrpc/client.go:257 +0x43b
==================
```

```
WARNING: DATA RACE
Write at 0x00c00d5bc000 by goroutine 1278:
  runtime.mapdelete_fast64()
      /usr/local/go/src/runtime/map_fast64.go:273 +0x0
  github.com/filecoin-project/go-jsonrpc.(*wsConn).closeChans()
      /home/aayush/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.2.3/websocket.go:528 +0x12b
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleWsConn.func3()
      /home/aayush/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.2.3/websocket.go:693 +0x39
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  github.com/filecoin-project/go-jsonrpc.websocketClient.func2.1()
      /home/aayush/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.2.3/client.go:258 +0x44
  runtime/pprof.Do()
      /usr/local/go/src/runtime/pprof/runtime.go:40 +0x122
  github.com/filecoin-project/go-jsonrpc.websocketClient.func2()
      /home/aayush/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.2.3/client.go:257 +0x457

Previous read at 0x00c00d5bc000 by goroutine 1282:
  runtime.mapaccess2_fast64()
      /usr/local/go/src/runtime/map_fast64.go:53 +0x0
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleChanMessage()
      /home/aayush/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.2.3/websocket.go:370 +0x384
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleFrame()
      /home/aayush/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.2.3/websocket.go:493 +0x124
  github.com/filecoin-project/go-jsonrpc.(*wsConn).frameExecutor()
      /home/aayush/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.2.3/websocket.go:666 +0x52f
  github.com/filecoin-project/go-jsonrpc.(*wsConn).handleWsConn.func5()
      /home/aayush/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.2.3/websocket.go:707 +0x58
```

Plus a few races in tests.