### PR TITLE
fix: make resp result/error conformant to spec

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -119,30 +119,15 @@ func (r response) MarshalJSON() ([]byte, error) {
 	// > `error`:
 	// > This member is REQUIRED on error.
 	// > This member MUST NOT exist if there was no error triggered during invocation.
+	data := make(map[string]interface{})
+	data["jsonrpc"] = r.Jsonrpc
+	data["id"] = r.ID
 	if r.Error != nil {
-		// If there's an error, exclude result
-		type responseWithoutResult struct {
-			Jsonrpc string      `json:"jsonrpc"`
-			ID      interface{} `json:"id"`
-			Error   *respError  `json:"error"`
-		}
-		return json.Marshal(&responseWithoutResult{
-			Jsonrpc: r.Jsonrpc,
-			ID:      r.ID,
-			Error:   r.Error,
-		})
+		data["error"] = r.Error
+	} else {
+		data["result"] = r.Result
 	}
-
-	type responseWithResult struct {
-		Jsonrpc string      `json:"jsonrpc"`
-		Result  interface{} `json:"result"`
-		ID      interface{} `json:"id"`
-	}
-	return json.Marshal(&responseWithResult{
-		Jsonrpc: r.Jsonrpc,
-		Result:  r.Result,
-		ID:      r.ID,
-	})
+	return json.Marshal(data)
 }
 
 type handler struct {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -127,16 +127,16 @@ func TestRawRequests(t *testing.T) {
 		}
 	}
 
-	t.Run("inc", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": [], "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1, 200))
-	t.Run("inc-null", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": null, "id": 1}`, `{"jsonrpc":"2.0","id":1}`, 1, 200))
-	t.Run("inc-noparam", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "id": 2}`, `{"jsonrpc":"2.0","id":2}`, 1, 200))
-	t.Run("add", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [10], "id": 4}`, `{"jsonrpc":"2.0","id":4}`, 10, 200))
+	t.Run("inc", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": [], "id": 1}`, `{"jsonrpc":"2.0","id":1,"result":null}`, 1, 200))
+	t.Run("inc-null", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "params": null, "id": 1}`, `{"jsonrpc":"2.0","id":1,"result":null}`, 1, 200))
+	t.Run("inc-noparam", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Inc", "id": 2}`, `{"jsonrpc":"2.0","id":2,"result":null}`, 1, 200))
+	t.Run("add", tc(`{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [10], "id": 4}`, `{"jsonrpc":"2.0","id":4,"result":null}`, 10, 200))
 	// Batch requests
 	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 5}`, `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}`, 0, 500))
-	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 6}]`, `[{"jsonrpc":"2.0","id":6}]`, 123, 200))
-	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 7},{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [-122], "id": 8}]`, `[{"jsonrpc":"2.0","id":7},{"jsonrpc":"2.0","id":8}]`, 1, 200))
-	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 9},{"jsonrpc": "2.0", "params": [-122], "id": 10}]`, `[{"jsonrpc":"2.0","id":9},{"error":{"code":-32601,"message":"method '' not found"},"id":10,"jsonrpc":"2.0"}]`, 123, 200))
-	t.Run("add", tc(`     [{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [-1], "id": 11}]   `, `[{"jsonrpc":"2.0","id":11}]`, -1, 200))
+	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 6}]`, `[{"jsonrpc":"2.0","id":6,"result":null}]`, 123, 200))
+	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 7},{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [-122], "id": 8}]`, `[{"jsonrpc":"2.0","id":7,"result":null},{"jsonrpc":"2.0","id":8,"result":null}]`, 1, 200))
+	t.Run("add", tc(`[{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [123], "id": 9},{"jsonrpc": "2.0", "params": [-122], "id": 10}]`, `[{"jsonrpc":"2.0","id":9,"result":null},{"error":{"code":-32601,"message":"method '' not found"},"id":10,"jsonrpc":"2.0"}]`, 123, 200))
+	t.Run("add", tc(`     [{"jsonrpc": "2.0", "method": "SimpleServerHandler.Add", "params": [-1], "id": 11}]   `, `[{"jsonrpc":"2.0","id":11,"result":null}]`, -1, 200))
 	t.Run("add", tc(``, `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid request"}}`, 0, 400))
 }
 


### PR DESCRIPTION
Closes https://github.com/filecoin-project/go-jsonrpc/issues/102

This is a more verbose version of https://github.com/filecoin-project/go-jsonrpc/pull/103, mainly because my Go-Fu is too weak to find the issue in that code that causes timeouts. Are there any performance regressions with this? How can I check it?

It works fine on _almost_ latest master, was https://github.com/filecoin-project/go-jsonrpc/commit/5c010e6267b05fc6909b8b1abff1e338fbf7532d a regression @magik6k?

```
❯ go test -count=1 -v ./... | tail
--- PASS: TestReverseCallDroppedConn (1.10s)
=== RUN   TestBigResult
    rpc_test.go:1607: skipping test due to requiced resources, set I_HAVE_A_LOT_OF_MEMORY_AND_TIME=1 to run
--- SKIP: TestBigResult (0.00s)
PASS
ok      github.com/filecoin-project/go-jsonrpc  7.408s
=== RUN   TestReaderProxy
--- PASS: TestReaderProxy (0.00s)
PASS
ok      github.com/filecoin-project/go-jsonrpc/httpio   0.352s
```