### PR TITLE
fix: handle errors not arising from the native jsonrpc server

### DIFF
--- a/client.go
+++ b/client.go
@@ -167,8 +167,9 @@ func httpClient(ctx context.Context, addr string, namespace string, outs []inter
 			return clientResponse{}, &RPCConnectionError{err}
 		}
 
-		// may be fail
-		if httpResp.StatusCode >= http.StatusBadRequest {
+		// likely a failure outside of our control and ability to inspect; jsonrpc server only ever
+		// returns json format errors with either a StatusBadRequest or a StatusInternalServerError
+		if httpResp.StatusCode > http.StatusBadRequest && httpResp.StatusCode != http.StatusInternalServerError {
 			return clientResponse{}, xerrors.Errorf("request failed, http status %s", httpResp.Status)
 		}
 

--- a/server.go
+++ b/server.go
@@ -109,9 +109,9 @@ func rpcError(wf func(func(io.Writer)), req *request, code ErrorCode, err error)
 	wf(func(w io.Writer) {
 		if hw, ok := w.(http.ResponseWriter); ok {
 			if code == rpcInvalidRequest {
-				hw.WriteHeader(400)
+				hw.WriteHeader(http.StatusBadRequest)
 			} else {
-				hw.WriteHeader(500)
+				hw.WriteHeader(http.StatusInternalServerError)
 			}
 		}
 


### PR DESCRIPTION
Alternative to https://github.com/filecoin-project/go-jsonrpc/pull/82 which causes a regression because it blocks normal 403 and 500 errors sent by a jsonrpc server error along with a JSON blob.