### PR TITLE
feat: adjust frame input processing, better debugging info

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"container/list"
 	"context"
 	"encoding/json"
 	"errors"
@@ -37,6 +38,43 @@ type frame struct {
 	Error  *respError      `json:"error,omitempty"`
 }
 
+type methodQueue struct {
+	frames *list.List
+	limit  int
+}
+
+type methodCount struct {
+	method string
+	count  int
+}
+
+func newMethodQueue(limit int) *methodQueue {
+	return &methodQueue{
+		frames: list.New(),
+		limit:  limit,
+	}
+}
+
+func (fq *methodQueue) Add(m string) {
+	if fq.frames.Len() >= fq.limit {
+		fq.frames.Remove(fq.frames.Front()) // remove oldest
+	}
+	fq.frames.PushBack(m)
+}
+
+func (fq methodQueue) MethodCounts() []methodCount {
+	counts := make(map[string]int)
+	for e := fq.frames.Front(); e != nil; e = e.Next() {
+		counts[e.Value.(string)]++
+	}
+
+	var out []methodCount
+	for k, v := range counts {
+		out = append(out, methodCount{method: k, count: v})
+	}
+	return out
+}
+
 type outChanReg struct {
 	reqID interface{}
 
@@ -49,6 +87,9 @@ type reqestHandler interface {
 }
 
 type wsConn struct {
+	// chanCtr is a counter used for identifying output channels on the server side
+	chanCtr uint64
+
 	// outside params
 	conn             *websocket.Conn
 	connFactory      func() (*websocket.Conn, error)
@@ -68,7 +109,8 @@ type wsConn struct {
 
 	readError chan error
 
-	frameExecQueue chan []byte
+	frameExecQueue chan frame
+	methodQueue    *methodQueue
 
 	// outgoing messages
 	writeLk sync.Mutex
@@ -92,9 +134,6 @@ type wsConn struct {
 	handlingLk sync.Mutex
 
 	spawnOutChanHandlerOnce sync.Once
-
-	// chanCtr is a counter used for identifying output channels on the server side
-	chanCtr uint64
 
 	registerCh chan outChanReg
 }
@@ -672,9 +711,27 @@ func (c *wsConn) readFrame(ctx context.Context, r io.Reader) {
 		return
 	}
 
-	c.frameExecQueue <- buf
-	if len(c.frameExecQueue) > cap(c.frameExecQueue)/2 {
-		log.Warnw("frame executor queue is backlogged", "queued", len(c.frameExecQueue), "cap", cap(c.frameExecQueue))
+	var frame frame
+	if err := json.Unmarshal(buf, &frame); err != nil {
+		log.Warnw("failed to unmarshal frame", "error", err)
+		// todo send invalid request response
+	} else {
+		var err error
+		frame.ID, err = normalizeID(frame.ID)
+		if err != nil {
+			log.Warnw("failed to normalize frame id", "error", err)
+			// todo send invalid request response
+		} else {
+			c.frameExecQueue <- frame
+			c.methodQueue.Add(frame.Method)
+			if len(c.frameExecQueue) > int(float64(cap(c.frameExecQueue))*2/3) {
+				msgParams := []interface{}{"queued", len(c.frameExecQueue), "capacity", cap(c.frameExecQueue)}
+				for _, methodCount := range c.methodQueue.MethodCounts() {
+					msgParams = append(msgParams, fmt.Sprintf("method<%s>", methodCount.method), methodCount.count)
+				}
+				log.Warnw("frame executor queue is backlogged", msgParams...)
+			}
+		}
 	}
 
 	// got the whole frame, can start reading the next one in background
@@ -686,22 +743,7 @@ func (c *wsConn) frameExecutor(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case buf := <-c.frameExecQueue:
-			var frame frame
-			if err := json.Unmarshal(buf, &frame); err != nil {
-				log.Warnw("failed to unmarshal frame", "error", err)
-				// todo send invalid request response
-				continue
-			}
-
-			var err error
-			frame.ID, err = normalizeID(frame.ID)
-			if err != nil {
-				log.Warnw("failed to normalize frame id", "error", err)
-				// todo send invalid request response
-				continue
-			}
-
+		case frame := <-c.frameExecQueue:
 			c.handleFrame(ctx, frame)
 		}
 	}
@@ -715,7 +757,8 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 
 	c.incoming = make(chan io.Reader)
 	c.readError = make(chan error, 1)
-	c.frameExecQueue = make(chan []byte, maxQueuedFrames)
+	c.frameExecQueue = make(chan frame, maxQueuedFrames)
+	c.methodQueue = newMethodQueue(maxQueuedFrames)
 	c.inflight = map[interface{}]clientRequest{}
 	c.handling = map[interface{}]context.CancelFunc{}
 	c.chanHandlers = map[uint64]*chanHandler{}


### PR DESCRIPTION
~An experiment that may help in addressing https://github.com/filecoin-project/lotus/issues/11920; I don't think I quite have the confidence to suggest this should ship in a release but I'd like to at least see the debugging output from this.~

This now just changes the threshold for warning logging from 1/2 capacity to 2/3rds.