### PR TITLE
feat: Custom transport mode

### DIFF
--- a/client.go
+++ b/client.go
@@ -152,6 +152,10 @@ func NewCustomClient(namespace string, outs []interface{}, doRequest func(ctx co
 			return clientResponse{}, xerrors.Errorf("marshalling request: %w", err)
 		}
 
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
 		rawResp, err := doRequest(ctx, b)
 		if err != nil {
 			return clientResponse{}, xerrors.Errorf("doRequest failed: %w", err)

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -127,6 +128,62 @@ func NewMergeClient(ctx context.Context, addr string, namespace string, outs []i
 		return nil, xerrors.Errorf("unknown url scheme '%s'", u.Scheme)
 	}
 
+}
+
+// NewCustomClient is like NewMergeClient in single-request (http) mode, except it allows for a custom doRequest function
+func NewCustomClient(namespace string, outs []interface{}, doRequest func(ctx context.Context, body []byte) (io.ReadCloser, error), opts ...Option) (ClientCloser, error) {
+	config := defaultConfig()
+	for _, o := range opts {
+		o(&config)
+	}
+
+	c := client{
+		namespace:     namespace,
+		paramEncoders: config.paramEncoders,
+		errors:        config.errors,
+	}
+
+	stop := make(chan struct{})
+	c.exiting = stop
+
+	c.doRequest = func(ctx context.Context, cr clientRequest) (clientResponse, error) {
+		b, err := json.Marshal(&cr.req)
+		if err != nil {
+			return clientResponse{}, xerrors.Errorf("marshalling request: %w", err)
+		}
+
+		rawResp, err := doRequest(ctx, b)
+		if err != nil {
+			return clientResponse{}, xerrors.Errorf("doRequest failed: %w", err)
+		}
+
+		defer rawResp.Close()
+
+		var resp clientResponse
+		if cr.req.ID != nil { // non-notification
+			if err := json.NewDecoder(rawResp).Decode(&resp); err != nil {
+				return clientResponse{}, xerrors.Errorf("unmarshaling response: %w", err)
+			}
+
+			if resp.ID, err = normalizeID(resp.ID); err != nil {
+				return clientResponse{}, xerrors.Errorf("failed to response ID: %w", err)
+			}
+
+			if resp.ID != cr.req.ID {
+				return clientResponse{}, xerrors.New("request and response id didn't match")
+			}
+		}
+
+		return resp, nil
+	}
+
+	if err := c.provide(outs); err != nil {
+		return nil, err
+	}
+
+	return func() {
+		close(stop)
+	}, nil
 }
 
 func httpClient(ctx context.Context, addr string, namespace string, outs []interface{}, requestHeader http.Header, config Config) (ClientCloser, error) {

--- a/server.go
+++ b/server.go
@@ -104,6 +104,10 @@ func (s *RPCServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.handleReader(ctx, r.Body, w, rpcError)
 }
 
+func (s *RPCServer) HandleRequest(ctx context.Context, r io.Reader, w io.Writer) {
+	s.handleReader(ctx, r, w, rpcError)
+}
+
 func rpcError(wf func(func(io.Writer)), req *request, code ErrorCode, err error) {
 	log.Errorf("RPC Error: %s", err)
 	wf(func(w io.Writer) {


### PR DESCRIPTION
This PR:
* Makes it possible to create a client with a callback allowing for use with custom transports
  * Curio needs this for doing RPC to a sub-process, I can see there being other neat uses for this too
* Adds a method on the Server handler which makes it possible to feed raw rpc frames into it and get responses, skipping the http layer
* Obviously adds a test
* Adds some docs to the README, also documenting reverse calling which I've noticed had zero docs