### PR TITLE
Check for a cancelled context for websocket connection.

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1604,7 +1604,7 @@ func (h *BigCallTestServerHandler) Ch(ctx context.Context) (<-chan int, error) {
 func TestBigResult(t *testing.T) {
 	if os.Getenv("I_HAVE_A_LOT_OF_MEMORY_AND_TIME") != "1" {
 		// needs ~40GB of memory and ~4 minutes to run
-		t.Skip("skipping test due to requiced resources, set I_HAVE_A_LOT_OF_MEMORY_AND_TIME=1 to run")
+		t.Skip("skipping test due to required resources, set I_HAVE_A_LOT_OF_MEMORY_AND_TIME=1 to run")
 	}
 
 	// setup server

--- a/websocket.go
+++ b/websocket.go
@@ -791,7 +791,7 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 				return // failed to reconnect
 			}
 		case <-ctx.Done():
-			log.Debugw("context cancelled", "lastAction", action, "time", time.Since(start))
+			log.Debugw("context cancelled", "error", ctx.Err(), "lastAction", action, "time", time.Since(start))
 			return
 		case req := <-c.requests:
 			action = fmt.Sprintf("send-request(%s,%v)", req.req.Method, req.req.ID)

--- a/websocket.go
+++ b/websocket.go
@@ -790,6 +790,9 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 			if !c.tryReconnect(ctx) {
 				return // failed to reconnect
 			}
+		case <-ctx.Done():
+			log.Debugw("context cancelled", "lastAction", action, "time", time.Since(start))
+			return
 		case req := <-c.requests:
 			action = fmt.Sprintf("send-request(%s,%v)", req.req.Method, req.req.ID)
 


### PR DESCRIPTION
This change adds a check for a cancelled context to the websocket connection handler. This aims to avoid the connnection handler getting stuck if the received context has been cancelled.