### PR TITLE
feat: add ConnectionType(ctx) for called methods to use

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	if os.Getenv("GOLOG_LOG_LEVEL") == "" {
+	if _, exists := os.LookupEnv("GOLOG_LOG_LEVEL"); !exists {
 		if err := logging.SetLogLevel("rpc", "DEBUG"); err != nil {
 			panic(err)
 		}
@@ -1024,7 +1024,7 @@ func TestChanClientReceiveAll(t *testing.T) {
 }
 
 func TestControlChanDeadlock(t *testing.T) {
-	if os.Getenv("GOLOG_LOG_LEVEL") == "" {
+	if _, exists := os.LookupEnv("GOLOG_LOG_LEVEL"); !exists {
 		_ = logging.SetLogLevel("rpc", "error")
 		defer func() {
 			_ = logging.SetLogLevel("rpc", "DEBUG")

--- a/server.go
+++ b/server.go
@@ -21,21 +21,25 @@ const (
 )
 
 // ConnectionType indicates the type of connection, this is set in the context and can be retrieved
-// with GetConnectionType
+// with GetConnectionType.
 type ConnectionType string
 
 const (
+	// ConnectionTypeUnknown indicates that the connection type cannot be determined, likely because
+	// it hasn't passed through an RPCServer.
 	ConnectionTypeUnknown ConnectionType = "unknown"
-	ConnectionTypeHTTP    ConnectionType = "http"
-	ConnectionTypeWS      ConnectionType = "websockets"
+	// ConnectionTypeHTTP indicates that the connection is an HTTP connection.
+	ConnectionTypeHTTP ConnectionType = "http"
+	// ConnectionTypeWS indicates that the connection is a WebSockets connection.
+	ConnectionTypeWS ConnectionType = "websockets"
 )
 
-var conectionTypeCtxKey = &struct{ name string }{"jsonrpc-connection-type"}
+var connectionTypeCtxKey = &struct{ name string }{"jsonrpc-connection-type"}
 
 // GetConnectionType returns the connection type of the request if it was set by an RPCServer.
-// A connection type of "unknown" means that the connection type was not set.
+// A connection type of ConnectionTypeUnknown means that the connection type was not set.
 func GetConnectionType(ctx context.Context) ConnectionType {
-	if v := ctx.Value(conectionTypeCtxKey); v != nil {
+	if v := ctx.Value(connectionTypeCtxKey); v != nil {
 		return v.(ConnectionType)
 	}
 	return ConnectionTypeUnknown
@@ -118,12 +122,12 @@ func (s *RPCServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	h := strings.ToLower(r.Header.Get("Connection"))
 	if strings.Contains(h, "upgrade") {
-		ctx = context.WithValue(ctx, conectionTypeCtxKey, ConnectionTypeWS)
+		ctx = context.WithValue(ctx, connectionTypeCtxKey, ConnectionTypeWS)
 		s.handleWS(ctx, w, r)
 		return
 	}
 
-	ctx = context.WithValue(ctx, conectionTypeCtxKey, ConnectionTypeHTTP)
+	ctx = context.WithValue(ctx, connectionTypeCtxKey, ConnectionTypeHTTP)
 	s.handleReader(ctx, r.Body, w, rpcError)
 }
 


### PR DESCRIPTION
Use case for this: lotus-gateway should be able to decide which methods are only available via websockets but we currently don't have a straightforward way to do this without snooping on the wire. This is a prerequisite for https://github.com/filecoin-project/lotus/issues/11153 which I'm thinking is the right thing to do for stateful calls that we can't properly meter as per https://github.com/filecoin-project/lotus/issues/11589.