### PR TITLE
feat: add 'Data' field to 'respError' struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,7 +71,7 @@ type clientResponse struct {
 	Jsonrpc string          `json:"jsonrpc"`
 	Result  json.RawMessage `json:"result"`
 	ID      interface{}     `json:"id"`
-	Error   *respError      `json:"error,omitempty"`
+	Error   *JSONRPCError   `json:"error,omitempty"`
 }
 
 type makeChanSink func() (context.Context, func([]byte, bool))

--- a/errors.go
+++ b/errors.go
@@ -58,3 +58,8 @@ type marshalable interface {
 	json.Marshaler
 	json.Unmarshaler
 }
+
+type DataError interface {
+	Error() string          // returns the message
+	ErrorData() interface{} // returns the error data
+}

--- a/errors.go
+++ b/errors.go
@@ -59,6 +59,13 @@ type marshalable interface {
 	json.Unmarshaler
 }
 
+// Error wraps RPC errors, which contain an error code in addition to the message.
+type Error interface {
+	Error() string  // returns the message
+	ErrorCode() int // returns the code
+}
+
+// DataError contains extra data to explain the error
 type DataError interface {
 	Error() string          // returns the message
 	ErrorData() interface{} // returns the error data

--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,7 @@ type marshalable interface {
 	json.Unmarshaler
 }
 
-type ErrorCodec interface {
+type RPCErrorCodec interface {
 	FromJSONRPCError(JSONRPCError) error
 	ToJSONRPCError() (JSONRPCError, error)
 }

--- a/errors.go
+++ b/errors.go
@@ -59,14 +59,14 @@ type marshalable interface {
 	json.Unmarshaler
 }
 
-// Error wraps RPC errors, which contain an error code in addition to the message.
-type Error interface {
+// ErrorWithCode wraps RPC errors, which contain an error code in addition to the message.
+type ErrorWithCode interface {
 	Error() string  // returns the message
 	ErrorCode() int // returns the code
 }
 
-// DataError contains extra data to explain the error
-type DataError interface {
+// ErrorWithData contains extra data to explain the error
+type ErrorWithData interface {
 	Error() string          // returns the message
 	ErrorData() interface{} // returns the error data
 }

--- a/errors.go
+++ b/errors.go
@@ -59,8 +59,7 @@ type marshalable interface {
 	json.Unmarshaler
 }
 
-// ErrorWithData contains extra data to explain the error
-type ErrorWithData interface {
-	Error() string          // returns the message
-	ErrorData() interface{} // returns the error data
+type ErrorCodec interface {
+	FromJSONRPCError(JSONRPCError) error
+	ToJSONRPCError() (JSONRPCError, error)
 }

--- a/errors.go
+++ b/errors.go
@@ -59,12 +59,6 @@ type marshalable interface {
 	json.Unmarshaler
 }
 
-// ErrorWithCode wraps RPC errors, which contain an error code in addition to the message.
-type ErrorWithCode interface {
-	Error() string  // returns the message
-	ErrorCode() int // returns the code
-}
-
 // ErrorWithData contains extra data to explain the error
 type ErrorWithData interface {
 	Error() string          // returns the message

--- a/handler.go
+++ b/handler.go
@@ -102,17 +102,17 @@ func (e *respError) val(errors *Errors) reflect.Value {
 
 			if len(e.Meta) > 0 && v.Type().Implements(marshalableRT) {
 				_ = v.Interface().(marshalable).UnmarshalJSON(e.Meta)
-			} else {
-				msgField := v.Elem().FieldByName("Message")
-				if msgField.IsValid() && msgField.CanSet() && msgField.Kind() == reflect.String {
-					msgField.SetString(e.Message)
-				}
+			}
 
-				if v.Type().Implements(errorsRT) {
-					dataField := v.Elem().FieldByName("Data")
-					if dataField.IsValid() && dataField.CanSet() {
-						dataField.Set(reflect.ValueOf(e.Data))
-					}
+			msgField := v.Elem().FieldByName("Message")
+			if msgField.IsValid() && msgField.CanSet() && msgField.Kind() == reflect.String {
+				msgField.SetString(e.Message)
+			}
+
+			if v.Type().Implements(errorsRT) {
+				dataField := v.Elem().FieldByName("Data")
+				if dataField.IsValid() && dataField.CanSet() {
+					dataField.Set(reflect.ValueOf(e.Data))
 				}
 			}
 

--- a/handler.go
+++ b/handler.go
@@ -365,7 +365,13 @@ func (s *handler) createError(err error) *respError {
 		}
 	}
 
-	if de, ok := err.(DataError); ok {
+	var err2 Error
+	if errors.As(err, &err2) {
+		out.Code = ErrorCode(err2.ErrorCode())
+	}
+
+	var de DataError
+	if errors.As(err, &de) {
 		out.Data = de.ErrorData()
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -69,6 +69,7 @@ type respError struct {
 	Code    ErrorCode       `json:"code"`
 	Message string          `json:"message"`
 	Meta    json.RawMessage `json:"meta,omitempty"`
+	Data    json.RawMessage `json:"data,omitempty"`
 }
 
 func (e *respError) Error() string {

--- a/handler.go
+++ b/handler.go
@@ -365,14 +365,14 @@ func (s *handler) createError(err error) *respError {
 		}
 	}
 
-	var err2 Error
-	if errors.As(err, &err2) {
-		out.Code = ErrorCode(err2.ErrorCode())
+	var ec ErrorWithCode
+	if errors.As(err, &ec) {
+		out.Code = ErrorCode(ec.ErrorCode())
 	}
 
-	var de DataError
-	if errors.As(err, &de) {
-		out.Data = de.ErrorData()
+	var ed ErrorWithData
+	if errors.As(err, &ed) {
+		out.Data = ed.ErrorData()
 	}
 
 	return out
@@ -529,7 +529,7 @@ func (s *handler) handle(ctx context.Context, req request, w func(func(io.Writer
 				Message: err.Error(),
 			}
 
-			var de DataError
+			var de ErrorWithData
 			if errors.As(err, &de) {
 				respErr.Data = de.ErrorData()
 			}

--- a/handler.go
+++ b/handler.go
@@ -287,7 +287,7 @@ func (s *handler) createError(err error) *JSONRPCError {
 	case RPCErrorCodec:
 		o, err := m.ToJSONRPCError()
 		if err != nil {
-			log.Warnf("Failed to convert error to JSONRPCError: %v", err)
+			log.Errorf("Failed to convert error to JSONRPCError: %w", err)
 		} else {
 			out = &o
 		}
@@ -296,7 +296,7 @@ func (s *handler) createError(err error) *JSONRPCError {
 		if marshalErr == nil {
 			out.Meta = meta
 		} else {
-			log.Warnf("Failed to marshal error metadata: %v", marshalErr)
+			log.Errorf("Failed to marshal error metadata: %w", marshalErr)
 		}
 	}
 
@@ -450,21 +450,10 @@ func (s *handler) handle(ctx context.Context, req request, w func(func(io.Writer
 			log.Warnf("failed to setup channel in RPC call to '%s': %+v", req.Method, err)
 			stats.Record(ctx, metrics.RPCResponseError.M(1))
 
-			respErr := &JSONRPCError{
+			resp.Error = &JSONRPCError{
 				Code:    1,
 				Message: err.Error(),
 			}
-
-			if m, ok := err.(RPCErrorCodec); ok {
-				rpcErr, err := m.ToJSONRPCError()
-				if err != nil {
-					log.Warnf("Failed to convert error to JSONRPCError: %v", err)
-				} else {
-					respErr.Data = rpcErr.Data
-				}
-			}
-
-			resp.Error = respErr
 		} else {
 			resp.Result = res
 		}

--- a/handler.go
+++ b/handler.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -65,95 +64,6 @@ type request struct {
 // entire HTTP body.
 // Configured by WithMaxRequestSize.
 const DEFAULT_MAX_REQUEST_SIZE = 100 << 20 // 100 MiB
-
-type respError struct {
-	Code    ErrorCode       `json:"code"`
-	Message string          `json:"message"`
-	Meta    json.RawMessage `json:"meta,omitempty"`
-	Data    interface{}     `json:"data,omitempty"`
-}
-
-func (e *respError) Error() string {
-	if e.Code >= -32768 && e.Code <= -32000 {
-		return fmt.Sprintf("RPC error (%d): %s", e.Code, e.Message)
-	}
-	return e.Message
-}
-
-func (e *respError) ErrorData() interface{} {
-	return e.Data
-}
-
-var (
-	marshalableRT = reflect.TypeOf(new(marshalable)).Elem()
-	errorsRT      = reflect.TypeOf(new(ErrorWithData)).Elem()
-)
-
-func (e *respError) val(errors *Errors) reflect.Value {
-	if errors != nil {
-		t, ok := errors.byCode[e.Code]
-		if ok {
-			var v reflect.Value
-			if t.Kind() == reflect.Ptr {
-				v = reflect.New(t.Elem())
-			} else {
-				v = reflect.New(t)
-			}
-
-			if len(e.Meta) > 0 && v.Type().Implements(marshalableRT) {
-				_ = v.Interface().(marshalable).UnmarshalJSON(e.Meta)
-			}
-
-			msgField := v.Elem().FieldByName("Message")
-			if msgField.IsValid() && msgField.CanSet() && msgField.Kind() == reflect.String {
-				msgField.SetString(e.Message)
-			}
-
-			if v.Type().Implements(errorsRT) {
-				dataField := v.Elem().FieldByName("Data")
-				if dataField.IsValid() && dataField.CanSet() {
-					dataField.Set(reflect.ValueOf(e.Data))
-				}
-			}
-
-			if t.Kind() != reflect.Ptr {
-				v = v.Elem()
-			}
-			return v
-		}
-	}
-
-	return reflect.ValueOf(e)
-}
-
-type response struct {
-	Jsonrpc string      `json:"jsonrpc"`
-	Result  interface{} `json:"result,omitempty"`
-	ID      interface{} `json:"id"`
-	Error   *respError  `json:"error,omitempty"`
-}
-
-func (r response) MarshalJSON() ([]byte, error) {
-	// Custom marshal logic as per JSON-RPC 2.0 spec:
-	// > `result`:
-	// > This member is REQUIRED on success.
-	// > This member MUST NOT exist if there was an error invoking the method.
-	//
-	// > `error`:
-	// > This member is REQUIRED on error.
-	// > This member MUST NOT exist if there was no error triggered during invocation.
-	data := map[string]interface{}{
-		"jsonrpc": r.Jsonrpc,
-		"id":      r.ID,
-	}
-
-	if r.Error != nil {
-		data["error"] = r.Error
-	} else {
-		data["result"] = r.Result
-	}
-	return json.Marshal(data)
-}
 
 type handler struct {
 	methods map[string]methodHandler
@@ -359,7 +269,7 @@ func (s *handler) getSpan(ctx context.Context, req request) (context.Context, *t
 	return ctx, span
 }
 
-func (s *handler) createError(err error) *respError {
+func (s *handler) createError(err error) *JSONRPCError {
 	var code ErrorCode = 1
 	if s.errors != nil {
 		c, ok := s.errors.byType[reflect.TypeOf(err)]
@@ -368,23 +278,26 @@ func (s *handler) createError(err error) *respError {
 		}
 	}
 
-	out := &respError{
+	out := &JSONRPCError{
 		Code:    code,
 		Message: err.Error(),
 	}
 
-	if m, ok := err.(marshalable); ok {
+	switch m := err.(type) {
+	case ErrorCodec:
+		o, err := m.ToJSONRPCError()
+		if err != nil {
+			log.Warnf("Failed to convert error to JSONRPCError: %v", err)
+		} else {
+			out = &o
+		}
+	case marshalable:
 		meta, marshalErr := m.MarshalJSON()
 		if marshalErr == nil {
 			out.Meta = meta
 		} else {
 			log.Warnf("Failed to marshal error metadata: %v", marshalErr)
 		}
-	}
-
-	var ed ErrorWithData
-	if errors.As(err, &ed) {
-		out.Data = ed.ErrorData()
 	}
 
 	return out
@@ -536,14 +449,19 @@ func (s *handler) handle(ctx context.Context, req request, w func(func(io.Writer
 
 			log.Warnf("failed to setup channel in RPC call to '%s': %+v", req.Method, err)
 			stats.Record(ctx, metrics.RPCResponseError.M(1))
-			respErr := &respError{
+
+			respErr := &JSONRPCError{
 				Code:    1,
 				Message: err.Error(),
 			}
 
-			var ed ErrorWithData
-			if errors.As(err, &ed) {
-				respErr.Data = ed.ErrorData()
+			if m, ok := err.(ErrorCodec); ok {
+				respErr, err := m.ToJSONRPCError()
+				if err != nil {
+					log.Warnf("Failed to convert error to JSONRPCError: %v", err)
+				} else {
+					resp.Error.Data = respErr.Data
+				}
 			}
 
 			resp.Error = respErr

--- a/handler.go
+++ b/handler.go
@@ -356,6 +356,12 @@ func (s *handler) createError(err error) *respError {
 		}
 	}
 
+	if dataErr, ok := err.(interface{ ErrorData() interface{} }); ok {
+		if data, err := json.Marshal(dataErr.ErrorData()); err == nil {
+			out.Data = data
+		}
+	}
+
 	return out
 }
 

--- a/handler.go
+++ b/handler.go
@@ -284,7 +284,7 @@ func (s *handler) createError(err error) *JSONRPCError {
 	}
 
 	switch m := err.(type) {
-	case ErrorCodec:
+	case RPCErrorCodec:
 		o, err := m.ToJSONRPCError()
 		if err != nil {
 			log.Warnf("Failed to convert error to JSONRPCError: %v", err)
@@ -455,12 +455,12 @@ func (s *handler) handle(ctx context.Context, req request, w func(func(io.Writer
 				Message: err.Error(),
 			}
 
-			if m, ok := err.(ErrorCodec); ok {
-				respErr, err := m.ToJSONRPCError()
+			if m, ok := err.(RPCErrorCodec); ok {
+				rpcErr, err := m.ToJSONRPCError()
 				if err != nil {
 					log.Warnf("Failed to convert error to JSONRPCError: %v", err)
 				} else {
-					resp.Error.Data = respErr.Data
+					respErr.Data = rpcErr.Data
 				}
 			}
 

--- a/handler.go
+++ b/handler.go
@@ -365,11 +365,6 @@ func (s *handler) createError(err error) *respError {
 		}
 	}
 
-	var ec ErrorWithCode
-	if errors.As(err, &ec) {
-		out.Code = ErrorCode(ec.ErrorCode())
-	}
-
 	var ed ErrorWithData
 	if errors.As(err, &ed) {
 		out.Data = ed.ErrorData()
@@ -529,9 +524,9 @@ func (s *handler) handle(ctx context.Context, req request, w func(func(io.Writer
 				Message: err.Error(),
 			}
 
-			var de ErrorWithData
-			if errors.As(err, &de) {
-				respErr.Data = de.ErrorData()
+			var ed ErrorWithData
+			if errors.As(err, &ed) {
+				respErr.Data = ed.ErrorData()
 			}
 
 			resp.Error = respErr

--- a/resp_error_test.go
+++ b/resp_error_test.go
@@ -1,0 +1,224 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Define the error types
+type SimpleError struct {
+	Message string
+}
+
+func (e *SimpleError) Error() string {
+	return e.Message
+}
+
+type DataError struct {
+	Message string
+	Data    interface{}
+}
+
+func (e *DataError) Error() string {
+	return e.Message
+}
+
+func (e *DataError) ErrorData() interface{} {
+	return e.Data
+}
+
+type MetaError struct {
+	Message string
+	Details string
+}
+
+func (e *MetaError) Error() string {
+	return e.Message
+}
+
+func (e *MetaError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Details string `json:"details"`
+	}{
+		Details: e.Details,
+	})
+}
+
+func (e *MetaError) UnmarshalJSON(data []byte) error {
+	var temp struct {
+		Details string `json:"details"`
+	}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	e.Details = temp.Details
+	return nil
+}
+
+type ComplexError struct {
+	Message string
+	Data    interface{}
+	Details string
+}
+
+func (e *ComplexError) Error() string {
+	return e.Message
+}
+
+func (e *ComplexError) ErrorData() interface{} {
+	return e.Data
+}
+
+func (e *ComplexError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Message string      `json:"message"`
+		Details string      `json:"details"`
+		Data    interface{} `json:"data"`
+	}{
+		Details: e.Details,
+		Message: e.Message,
+		Data:    e.Data,
+	})
+}
+
+func (e *ComplexError) UnmarshalJSON(data []byte) error {
+	var temp struct {
+		Message string      `json:"message"`
+		Details string      `json:"details"`
+		Data    interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	e.Details = temp.Details
+	e.Message = temp.Message
+	e.Data = temp.Data
+	return nil
+}
+
+func TestRespErrorVal(t *testing.T) {
+	// Initialize the Errors struct and register error types
+	errorsMap := NewErrors()
+	errorsMap.Register(1001, new(*SimpleError))
+	errorsMap.Register(1002, new(*DataError))
+	errorsMap.Register(1003, new(*MetaError))
+	errorsMap.Register(1004, new(*ComplexError))
+
+	// Define test cases
+	testCases := []struct {
+		name         string
+		respError    *respError
+		expectedType reflect.Type
+		verify       func(err error) error
+	}{
+		{
+			name: "SimpleError",
+			respError: &respError{
+				Code:    1001,
+				Message: "simple error occurred",
+			},
+			expectedType: reflect.TypeOf(&SimpleError{}),
+			verify: func(err error) error {
+				require.IsType(t, &SimpleError{}, err)
+				require.Equal(t, "simple error occurred", err.Error())
+				return nil
+			},
+		},
+		{
+			name: "DataError",
+			respError: &respError{
+				Code:    1002,
+				Message: "data error occurred",
+				Data:    "additional data",
+			},
+			expectedType: reflect.TypeOf(&DataError{}),
+			verify: func(err error) error {
+				require.IsType(t, &DataError{}, err)
+				require.Equal(t, "data error occurred", err.Error())
+				require.Equal(t, "additional data", err.(*DataError).ErrorData())
+				return nil
+			},
+		},
+		{
+			name: "MetaError",
+			respError: &respError{
+				Code:    1003,
+				Message: "meta error occurred",
+				Meta: func() json.RawMessage {
+					me := &MetaError{
+						Details: "meta details",
+					}
+					metaData, _ := me.MarshalJSON()
+					return metaData
+				}(),
+			},
+			expectedType: reflect.TypeOf(&MetaError{}),
+			verify: func(err error) error {
+				require.IsType(t, &MetaError{}, err)
+				require.Equal(t, "meta error occurred", err.Error())
+				// details will also be included in the error message since it implements the marshable interface
+				require.Equal(t, "meta details", err.(*MetaError).Details)
+				return nil
+			},
+		},
+		{
+			name: "ComplexError",
+			respError: &respError{
+				Code:    1004,
+				Message: "complex error occurred",
+				Data:    "complex data",
+				Meta: func() json.RawMessage {
+					ce := &ComplexError{
+						Details: "complex details",
+					}
+					metaData, _ := ce.MarshalJSON()
+					return metaData
+				}(),
+			},
+			expectedType: reflect.TypeOf(&ComplexError{}),
+			verify: func(err error) error {
+				require.IsType(t, &ComplexError{}, err)
+				require.Equal(t, "complex error occurred", err.Error())
+				require.Equal(t, "complex data", err.(*ComplexError).ErrorData())
+				require.Equal(t, "complex details", err.(*ComplexError).Details)
+				return nil
+			},
+		},
+		{
+			name: "UnregisteredError",
+			respError: &respError{
+				Code:    9999,
+				Message: "unregistered error occurred",
+				Data:    "some data",
+			},
+			expectedType: reflect.TypeOf(&respError{}),
+			verify: func(err error) error {
+				require.IsType(t, &respError{}, err)
+				require.Equal(t, "unregistered error occurred", err.Error())
+				require.Equal(t, "some data", err.(*respError).ErrorData())
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errValue := tc.respError.val(&errorsMap)
+			errInterface := errValue.Interface()
+			err, ok := errInterface.(error)
+			if !ok {
+				t.Fatalf("returned value does not implement error interface")
+			}
+
+			if reflect.TypeOf(err) != tc.expectedType {
+				t.Errorf("expected error type %v, got %v", tc.expectedType, reflect.TypeOf(err))
+			}
+
+			err = tc.verify(err)
+			require.NoError(t, err, "failed to verify error")
+		})
+	}
+}

--- a/resp_error_test.go
+++ b/resp_error_test.go
@@ -35,7 +35,7 @@ func (e *SimpleError) ToJSONRPCError() (JSONRPCError, error) {
 	return JSONRPCError{Message: e.Message}, nil
 }
 
-var _ ErrorCodec = (*SimpleError)(nil)
+var _ RPCErrorCodec = (*SimpleError)(nil)
 
 type DataStringError struct {
 	Message string `json:"message"`
@@ -62,7 +62,7 @@ func (e *DataStringError) ToJSONRPCError() (JSONRPCError, error) {
 	return JSONRPCError{Message: e.Message, Data: e.Data}, nil
 }
 
-var _ ErrorCodec = (*DataStringError)(nil)
+var _ RPCErrorCodec = (*DataStringError)(nil)
 
 type DataComplexError struct {
 	Message      string
@@ -94,7 +94,7 @@ func (e *DataComplexError) ToJSONRPCError() (JSONRPCError, error) {
 	return JSONRPCError{Message: e.Message, Data: data}, nil
 }
 
-var _ ErrorCodec = (*DataComplexError)(nil)
+var _ RPCErrorCodec = (*DataComplexError)(nil)
 
 type MetaError struct {
 	Message string

--- a/response.go
+++ b/response.go
@@ -1,0 +1,85 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+type response struct {
+	Jsonrpc string        `json:"jsonrpc"`
+	Result  interface{}   `json:"result,omitempty"`
+	ID      interface{}   `json:"id"`
+	Error   *JSONRPCError `json:"error,omitempty"`
+}
+
+func (r response) MarshalJSON() ([]byte, error) {
+	// Custom marshal logic as per JSON-RPC 2.0 spec:
+	// > `result`:
+	// > This member is REQUIRED on success.
+	// > This member MUST NOT exist if there was an error invoking the method.
+	//
+	// > `error`:
+	// > This member is REQUIRED on error.
+	// > This member MUST NOT exist if there was no error triggered during invocation.
+	data := map[string]interface{}{
+		"jsonrpc": r.Jsonrpc,
+		"id":      r.ID,
+	}
+
+	if r.Error != nil {
+		data["error"] = r.Error
+	} else {
+		data["result"] = r.Result
+	}
+	return json.Marshal(data)
+}
+
+type JSONRPCError struct {
+	Code    ErrorCode       `json:"code"`
+	Message string          `json:"message"`
+	Meta    json.RawMessage `json:"meta,omitempty"`
+	Data    interface{}     `json:"data,omitempty"`
+}
+
+func (e *JSONRPCError) Error() string {
+	if e.Code >= -32768 && e.Code <= -32000 {
+		return fmt.Sprintf("RPC error (%d): %s", e.Code, e.Message)
+	}
+	return e.Message
+}
+
+var (
+	_               error = (*JSONRPCError)(nil)
+	marshalableRT         = reflect.TypeOf(new(marshalable)).Elem()
+	unmarshalableRT       = reflect.TypeOf(new(ErrorCodec)).Elem()
+)
+
+func (e *JSONRPCError) val(errors *Errors) reflect.Value {
+	if errors != nil {
+		t, ok := errors.byCode[e.Code]
+		if ok {
+			var v reflect.Value
+			if t.Kind() == reflect.Ptr {
+				v = reflect.New(t.Elem())
+			} else {
+				v = reflect.New(t)
+			}
+
+			if v.Type().Implements(unmarshalableRT) {
+				_ = v.Interface().(ErrorCodec).FromJSONRPCError(*e)
+			}
+
+			if len(e.Meta) > 0 && v.Type().Implements(marshalableRT) {
+				_ = v.Interface().(marshalable).UnmarshalJSON(e.Meta)
+			}
+
+			if t.Kind() != reflect.Ptr {
+				v = v.Elem()
+			}
+			return v
+		}
+	}
+
+	return reflect.ValueOf(e)
+}

--- a/response.go
+++ b/response.go
@@ -68,14 +68,12 @@ func (e *JSONRPCError) val(errors *Errors) reflect.Value {
 
 			if v.Type().Implements(errorCodecRT) {
 				if err := v.Interface().(RPCErrorCodec).FromJSONRPCError(*e); err != nil {
-					log.Errorf("Error converting JSONRPCError (code %d) to custom error type '%s': %w", e.Code, t.String(), err)
+					log.Errorf("Error converting JSONRPCError to custom error type '%s' (code %d): %w", t.String(), e.Code, err)
 					return reflect.ValueOf(e)
 				}
-			}
-
-			if len(e.Meta) > 0 && v.Type().Implements(marshalableRT) {
+			} else if len(e.Meta) > 0 && v.Type().Implements(marshalableRT) {
 				if err := v.Interface().(marshalable).UnmarshalJSON(e.Meta); err != nil {
-					log.Errorf("Error unmarshaling metadata for error type '%s': %w", t.String(), err)
+					log.Errorf("Error unmarshalling error metadata to custom error type '%s' (code %d): %w", t.String(), e.Code, err)
 					return reflect.ValueOf(e)
 				}
 			}

--- a/response.go
+++ b/response.go
@@ -52,7 +52,7 @@ func (e *JSONRPCError) Error() string {
 var (
 	_               error = (*JSONRPCError)(nil)
 	marshalableRT         = reflect.TypeOf(new(marshalable)).Elem()
-	unmarshalableRT       = reflect.TypeOf(new(ErrorCodec)).Elem()
+	unmarshalableRT       = reflect.TypeOf(new(RPCErrorCodec)).Elem()
 )
 
 func (e *JSONRPCError) val(errors *Errors) reflect.Value {
@@ -67,7 +67,7 @@ func (e *JSONRPCError) val(errors *Errors) reflect.Value {
 			}
 
 			if v.Type().Implements(unmarshalableRT) {
-				_ = v.Interface().(ErrorCodec).FromJSONRPCError(*e)
+				_ = v.Interface().(RPCErrorCodec).FromJSONRPCError(*e)
 			}
 
 			if len(e.Meta) > 0 && v.Type().Implements(marshalableRT) {

--- a/server.go
+++ b/server.go
@@ -155,7 +155,7 @@ func rpcError(wf func(func(io.Writer)), req *request, code ErrorCode, err error)
 		resp := response{
 			Jsonrpc: "2.0",
 			ID:      req.ID,
-			Error: &respError{
+			Error: &JSONRPCError{
 				Code:    code,
 				Message: err.Error(),
 			},
@@ -180,4 +180,4 @@ func (s *RPCServer) AliasMethod(alias, original string) {
 	s.aliasedMethods[alias] = original
 }
 
-var _ error = &respError{}
+var _ error = &JSONRPCError{}

--- a/websocket.go
+++ b/websocket.go
@@ -34,7 +34,7 @@ type frame struct {
 
 	// response
 	Result json.RawMessage `json:"result,omitempty"`
-	Error  *respError      `json:"error,omitempty"`
+	Error  *JSONRPCError   `json:"error,omitempty"`
 }
 
 type outChanReg struct {
@@ -529,7 +529,7 @@ func (c *wsConn) closeInFlight() {
 		req.ready <- clientResponse{
 			Jsonrpc: "2.0",
 			ID:      id,
-			Error: &respError{
+			Error: &JSONRPCError{
 				Message: "handler: websocket connection closed",
 				Code:    eTempWSError,
 			},
@@ -802,7 +802,7 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 					req.ready <- clientResponse{
 						Jsonrpc: "2.0",
 						ID:      req.req.ID,
-						Error: &respError{
+						Error: &JSONRPCError{
 							Message: "handler: websocket connection closed",
 							Code:    eTempWSError,
 						},
@@ -824,7 +824,7 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 					Jsonrpc: "2.0",
 				}
 				if serr != nil {
-					resp.Error = &respError{
+					resp.Error = &JSONRPCError{
 						Code:    eTempWSError,
 						Message: fmt.Sprintf("sendRequest: %s", serr),
 					}


### PR DESCRIPTION
This pull request includes a small change to the `handler.go` file. The change adds an optional `Data` field to the `respError` struct. This is done so as to implement changes mentioned in https://github.com/filecoin-project/lotus/issues/10311

* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R72): Added `Data` field to the `respError` struct to include additional error information.