### PR TITLE
feat: add method name formatter option for client handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,11 +323,116 @@ func main() {
         nil,
         jsonrpc.WithMethodNameFormatter(jsonrpc.NewMethodNameFormatter(false, OriginalCase)),
         jsonrpc.WithClientHandler("Client", &RevCallTestClientHandler{}),
-		jsonrpc.WithClientHandlerFormatter(jsonrpc.NewMethodNameFormatter(false, OriginalCase)),
+        jsonrpc.WithClientHandlerFormatter(jsonrpc.NewMethodNameFormatter(false, OriginalCase)),
     )
     defer closer()
 }
 ```
+### Using method name alias
+
+You can also create an alias for a method name. This is useful if you want to use a different method name in the JSON-RPC
+request than the actual method name for a specific method.
+
+#### Usage of method name alias in the server
+
+```go
+type SimpleServerHandler struct {}
+
+func (h *SimpleServerHandler) Double(in int) int {
+    return in * 2
+}
+
+// create a new server instance
+rpcServer := jsonrpc.NewServer()
+
+// create a handler instance and register it
+serverHandler := &SimpleServerHandler{}
+rpcServer.Register("SimpleServerHandler", serverHandler)
+
+// create an alias for the Double method. This will allow you to call the server's Double method
+// with the name "rand_myRandomAlias" in the JSON-RPC request.
+rpcServer.AliasMethod("rand_myRandomAlias", "SimpleServerHandler.Double")
+
+```
+
+#### Usage of method name alias with client handlers
+
+```go
+// setup the client handler
+type ReverseHandler struct {}
+
+func (h *ReverseHandler) DoubleOnClient(in int) int {
+    return in * 2
+}
+
+// create a new client instance with the client handler + method name alias
+closer, err := jsonrpc.NewMergeClient(
+    context.Background(),
+    "http://example.com",
+    "SimpleServerHandler",
+    []any{&client},
+    nil,
+    jsonrpc.WithClientHandler("Client", &ReverseHandler{}),
+    // this allows the server to call the client's DoubleOnClient method using the name "rand_theClientRandomAlias" in the JSON-RPC request.
+    jsonrpc.WithClientHandlerAlias("rand_theClientRandomAlias", "Client.DoubleOnClient"),
+)
+```
+
+#### Usage of a struct tag to define method name alias
+
+There are two cases where you can also use the `rpc_method` struct tag to define method name alias:
+in the client struct and in the reverse handler struct in the server. 
+
+In the client struct:
+```go
+// setup the client struct
+var client struct {
+    AddInt func(int) int `rpc_method:"rand_aRandomAlias"`
+}
+
+// create a new client instance with the client struct that has the `rpc_method` struct tag
+closer, err := jsonrpc.NewMergeClient(
+    context.Background(),
+    "http://example.com",
+    "SimpleServerHandler",
+    []any{&client},
+    nil,
+)
+
+// since we defined the method name alias in the client struct, this will send a JSON-RPC request with "rand_aRandomAlias" as the method name to the
+// server instead of "SimpleServerHandler.AddInt".
+result, err := client.AddInt(10)
+
+```
+
+In the server's reverse handler struct:
+
+```go
+// Define the client handler interface
+type ClientHandler struct {
+    CallOnClient func(int) (int, error) `rpc_method:"rand_theClientRandomAlias"`
+}
+
+// Define the server handler
+type ServerHandler struct {}
+
+func (h *ServerHandler) Call(ctx context.Context) (int, error) {
+    revClient, _ := jsonrpc.ExtractReverseClient[ClientHandler](ctx)
+
+    // Reverse call to the client.
+    // Since we defined the method name alias in the client handler struct tag, this
+    // will send a JSON-RPC request with "rand_theClientRandomAlias" as the method name to the
+    // client instead of "Client.CallOnClient".
+    result, err := revClient.CallOnClient(7)
+    
+    // ...
+}
+
+// Setup server with reverse client capability
+rpcServer := jsonrpc.NewServer(jsonrpc.WithReverseClient[ClientHandler]("Client"))
+rpcServer.Register("ServerHandler", &ServerHandler{})
+```
+
 
 ## Contribute
 

--- a/client.go
+++ b/client.go
@@ -305,7 +305,11 @@ func websocketClient(ctx context.Context, addr string, namespace string, outs []
 
 	var hnd reqestHandler
 	if len(config.reverseHandlers) > 0 {
-		h := makeHandler(defaultServerConfig())
+		sc := defaultServerConfig()
+		if config.reverseHandlersFormatter != nil {
+			sc.methodNameFormatter = config.reverseHandlersFormatter
+		}
+		h := makeHandler(sc)
 		h.aliasedMethods = config.aliasedHandlerMethods
 		for _, reverseHandler := range config.reverseHandlers {
 			h.register(reverseHandler.ns, reverseHandler.hnd)

--- a/options.go
+++ b/options.go
@@ -23,8 +23,9 @@ type Config struct {
 	paramEncoders map[reflect.Type]ParamEncoder
 	errors        *Errors
 
-	reverseHandlers       []clientHandler
-	aliasedHandlerMethods map[string]string
+	reverseHandlers          []clientHandler
+	reverseHandlersFormatter MethodNameFormatter
+	aliasedHandlerMethods    map[string]string
 
 	httpClient *http.Client
 
@@ -98,6 +99,13 @@ func WithErrors(es Errors) func(c *Config) {
 func WithClientHandler(ns string, hnd interface{}) func(c *Config) {
 	return func(c *Config) {
 		c.reverseHandlers = append(c.reverseHandlers, clientHandler{ns, hnd})
+	}
+}
+
+// Just like WithMethodNameFormatter, but for client handlers.
+func WithClientHandlerFormatter(namer MethodNameFormatter) func(c *Config) {
+	return func(c *Config) {
+		c.reverseHandlersFormatter = namer
 	}
 }
 


### PR DESCRIPTION
Solves https://github.com/filecoin-project/go-jsonrpc/issues/136

This PR allows a user to specify a method name formatter for a client handler on the client side.
Although we can create a client handler to accept reversed calls from the server, it wasn't possible to configure a method name format for it (like `WithMethodNameFormatter`). This restricts the use of reverse calls to the default method name formatter, so it wasn't possible to accept a reverse call with a different method name format (like the `eth_subscription` method name).

Note: while creating a test for this new method, I studied other tests and found an undocumented feature: method name alias. This can also solve the above issue, but it requires creating an alias for every method name. The new solution proposed by this PR is applied to the entire client handler. I've updated the docs to improve DX.

Note: in the server, the formatter specified by the `WithServerMethodNameFormatter` config is also applied to the reverse calls. Do you want me to change this?

Regards