### PR TITLE
fix(http): always set Content-Type to application/json

### DIFF
--- a/server.go
+++ b/server.go
@@ -127,6 +127,9 @@ func (s *RPCServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Set Content-Type header for JSON-RPC responses
+	w.Header().Set("Content-Type", "application/json")
+
 	ctx = context.WithValue(ctx, connectionTypeCtxKey, ConnectionTypeHTTP)
 	s.handleReader(ctx, r.Body, w, rpcError)
 }


### PR DESCRIPTION
JSON-RPC HTTP responses were returning `Content-Type: text/plain; charset=utf-8` instead of the correct `application/json`. Added `w.Header().Set("Content-Type", "application/json")` in the `ServeHTTP` method for HTTP responses.

Ref: https://github.com/filecoin-project/lotus/issues/13390

